### PR TITLE
Update environment variables and refactor endpoints for relayer deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-FAUCET_BASE_URL=https://faucet-rpc.twilight.rest
-LCD_BASE_URL=https://lcd.twilight.rest
-ZKOS_SERVER_URL=https://nykschain.twilight.rest/zkos
+FAUCET_BASE_URL=https://faucet-rpc.twilight.rest # port 6969
+NYKS_LCD_BASE_URL=https://lcd.twilight.rest # port 1317
+NYKS_RPC_BASE_URL=https://rpc.twilight.rest # port 26657
+ZKOS_SERVER_URL=https://nykschain.twilight.rest/zkos # port 3030
 RUST_LOG=info

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ relayer_deployer*
 
 README_old.md
 test2.json
+test3.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde-this-or-that = "0.4.2"
 uuid = { version = "1.6.1", features = ["v4", "serde"] }
 lazy_static = "1.4.0"
 # #########################################################
-
+bitcoin = { version = "0.32.6", features = ["rand"] }
 bincode = "1.3.3"
 ripemd = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -41,22 +41,22 @@ The resulting binary will be at `target/release/relayer-init`.
 
 `relayer-init` talks to several Twilight test-net services. Endpoints are looked up via environment variables and **panic if they are not set**.
 
-| Variable            | Default value                          | Notes                          |
-| ------------------- | -------------------------------------- | ------------------------------ |
-| `NYKS_LCD_BASE_URL` | `https://lcd.twilight.rest`            | NYKS chain LCD (REST) endpoint |
-| `NYKS_RPC_BASE_URL` | `https://rpc.twilight.rest`            | NYKS chain LCD (REST) endpoint |
-| `FAUCET_BASE_URL`   | `https://faucet-rpc.twilight.rest`     | Nyks / BTC faucet services     |
-| `ZKOS_SERVER_URL`   | `https://nykschain.twilight.rest/zkos` | ZkOS JSON-RPC endpoint         |
-| `RUST_LOG`          | `info`                                 | Logging info                   |
+| Variable            | Default value                                                        | Notes                          |
+| ------------------- | -------------------------------------------------------------------- | ------------------------------ |
+| `NYKS_LCD_BASE_URL` | `http://0.0.0.0:1317` (public: https://lcd.twilight.rest)            | NYKS chain LCD (REST) endpoint |
+| `NYKS_RPC_BASE_URL` | `http://0.0.0.0:26657` (public: https://rpc.twilight.rest)           | NYKS chain RPC endpoint        |
+| `FAUCET_BASE_URL`   | `http://0.0.0.0:6969` (public: https://faucet-rpc.twilight.rest)     | Nyks / BTC faucet services     |
+| `ZKOS_SERVER_URL`   | `http://0.0.0.0:3030` (public: https://nykschain.twilight.rest/zkos) | ZkOS JSON-RPC endpoint         |
+| `RUST_LOG`          | `info`                                                               | Logging info                   |
 
 ### 3.1 Create a `.env` file (recommended)
 
 ```bash
 cat <<'EOF' > .env
-NYKS_LCD_BASE_URL=https://lcd.twilight.rest
-NYKS_RPC_BASE_URL=https://RPC.twilight.rest
-FAUCET_BASE_URL=https://faucet-rpc.twilight.rest
-ZKOS_SERVER_URL=https://nykschain.twilight.rest/zkos
+NYKS_LCD_BASE_URL=http://0.0.0.0:1317
+NYKS_RPC_BASE_URL=http://0.0.0.0:26657
+FAUCET_BASE_URL=http://0.0.0.0:6969
+ZKOS_SERVER_URL=http://0.0.0.0:3030
 RUST_LOG=info
 
 EOF

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -22,7 +22,7 @@ Make sure the following tools are available on your system:
 
 ```bash
 # clone the repository
-$ git clone https://github.com/your-org/nyks-wallet.git
+$ git clone https://github.com/twilight-project/nyks-wallet.git
 $ cd nyks-wallet
 
 # (optional) update package lists and install protoc

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Relayer-Init Deployment Guide
 
-This document explains how to build and run the `relayer_init` binary that ships with **nyks-wallet**.
+This document explains how to build and run the `relayer-init` binary that ships with **nyks-wallet**.
 
 ---
 
@@ -29,30 +29,32 @@ $ cd nyks-wallet
 $ sudo apt-get update
 $ sudo apt-get install protobuf-compiler
 
-# compile only relayer_init in release mode
-$ cargo build --release --bin relayer_init
+# compile only relayer-init in release mode
+$ cargo build --release --bin relayer-init
 ```
 
-The resulting binary will be at `target/release/relayer_init`.
+The resulting binary will be at `target/release/relayer-init`.
 
 ---
 
 ## 3. Configure endpoints
 
-`relayer_init` talks to several Twilight test-net services. Endpoints are looked up via environment variables and **panic if they are not set**.
+`relayer-init` talks to several Twilight test-net services. Endpoints are looked up via environment variables and **panic if they are not set**.
 
-| Variable          | Default value                          | Notes                          |
-| ----------------- | -------------------------------------- | ------------------------------ |
-| `LCD_BASE_URL`    | `https://lcd.twilight.rest`            | NYKS chain LCD (REST) endpoint |
-| `FAUCET_BASE_URL` | `https://faucet-rpc.twilight.rest`     | Nyks / BTC faucet services     |
-| `ZKOS_SERVER_URL` | `https://nykschain.twilight.rest/zkos` | ZkOS JSON-RPC endpoint         |
-| `RUST_LOG`        | `info`                                 | Logging info                   |
+| Variable            | Default value                          | Notes                          |
+| ------------------- | -------------------------------------- | ------------------------------ |
+| `NYKS_LCD_BASE_URL` | `https://lcd.twilight.rest`            | NYKS chain LCD (REST) endpoint |
+| `NYKS_RPC_BASE_URL` | `https://rpc.twilight.rest`            | NYKS chain LCD (REST) endpoint |
+| `FAUCET_BASE_URL`   | `https://faucet-rpc.twilight.rest`     | Nyks / BTC faucet services     |
+| `ZKOS_SERVER_URL`   | `https://nykschain.twilight.rest/zkos` | ZkOS JSON-RPC endpoint         |
+| `RUST_LOG`          | `info`                                 | Logging info                   |
 
 ### 3.1 Create a `.env` file (recommended)
 
 ```bash
 cat <<'EOF' > .env
-LCD_BASE_URL=https://lcd.twilight.rest
+NYKS_LCD_BASE_URL=https://lcd.twilight.rest
+NYKS_RPC_BASE_URL=https://RPC.twilight.rest
 FAUCET_BASE_URL=https://faucet-rpc.twilight.rest
 ZKOS_SERVER_URL=https://nykschain.twilight.rest/zkos
 RUST_LOG=info
@@ -72,28 +74,29 @@ You can also pass variables inline for a single execution:
 
 ```bash
 ZKOS_SERVER_URL=https://nykschain.twilight.rest/zkos \
-LCD_BASE_URL=https://lcd.twilight.rest \
+NYKS_LCD_BASE_URL=https://lcd.twilight.rest \
+NYKS_RPC_BASE_URL=https://rpc.twilight.rest \
 FAUCET_BASE_URL=https://faucet-rpc.twilight.rest \
 RUST_LOG=info \
-cargo run --bin relayer_init
+cargo run --bin relayer-init
 ```
 
 ---
 
-## 4. Run `relayer_init`
+## 4. Run `relayer-init`
 
 With the environment configured you can start the program either via **cargo** (dev-friendly) or the compiled binary (faster start-up):
 
 ### 4.1 Cargo
 
 ```bash
-cargo run --bin relayer_init  # uses the current directory’s source
+cargo run --bin relayer-init  # uses the current directory’s source
 ```
 
 ### 4.2 Pre-built binary
 
 ```bash
-./target/release/relayer_init
+./target/release/relayer-init
 ```
 
 Both modes will:
@@ -122,7 +125,7 @@ Logs are printed to stdout – watch for **“Successfully wrote relayer data to
 cargo clean
 
 # rebuild after changing code
-autoenv | source .env && cargo run --bin relayer_init
+autoenv | source .env && cargo run --bin relayer-init
 ```
 
 ---
@@ -148,7 +151,8 @@ docker build -t relayer-init .
 ```bash
 # current directory will receive relayer_deployer.json
 docker run --rm \
-  -e LCD_BASE_URL=https://lcd.twilight.rest \
+  -e NYKS_LCD_BASE_URL=https://lcd.twilight.rest \
+  -e NYKS_RPC_BASE_URL=https://rpc.twilight.rest \
   -e FAUCET_BASE_URL=https://faucet-rpc.twilight.rest \
   -e ZKOS_SERVER_URL=https://nykschain.twilight.rest/zkos \
   -e RUST_LOG=info \

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -22,7 +22,7 @@ Make sure the following tools are available on your system:
 
 ```bash
 # clone the repository
-$ git clone -b relayer-deployer https://github.com/your-org/nyks-wallet.git
+$ git clone https://github.com/your-org/nyks-wallet.git
 $ cd nyks-wallet
 
 # (optional) update package lists and install protoc

--- a/QuickStart.md
+++ b/QuickStart.md
@@ -6,7 +6,7 @@ This guide gets you from **zero to a funded test wallet in ~60 seconds**. For a 
 
 ## 1 • Prerequisites
 
-| Tool           | Min. version                            | Install                                                     |
+| Tool           | Min. version                            | Install                                                     |                                      |
 | -------------- | --------------------------------------- | ----------------------------------------------------------- | ------------------------------------ |
 | Rust toolchain | 2024-edition nightly (or stable ≥ 1.75) | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs` |                                      |
 | protoc         | ≥ 3.0                                   | Ubuntu `sudo apt install protobuf-compiler` &nbsp;          | &nbsp; macOS `brew install protobuf` |

--- a/QuickStart.md
+++ b/QuickStart.md
@@ -37,7 +37,8 @@ Nyks Wallet talks to the public Twilight test-net. Endpoints are read from envir
 
 ```bash
 cat <<'EOF' > .env.blbal
-LCD_BASE_URL=https://lcd.twilight.rest
+NYKS_LCD_BASE_URL=https://lcd.twilight.rest
+NYKS_RPC_BASE_URL=https://rpc.twilight.rest
 FAUCET_BASE_URL=https://faucet-rpc.twilight.rest
 ZKOS_SERVER_URL=https://nykschain.twilight.rest/zkos
 RUST_LOG=info

--- a/QuickStart.md
+++ b/QuickStart.md
@@ -20,7 +20,7 @@ This guide gets you from **zero to a funded test wallet in ~60 seconds**. For a 
 
 ```bash
 # grab the source
-$ git clone https://github.com/your-org/nyks-wallet.git
+$ git clone https://github.com/twilight-project/nyks-wallet.git
 $ cd nyks-wallet
 
 # compile everything in release mode (≈ 40 s on a modern laptop)

--- a/QuickStart.md
+++ b/QuickStart.md
@@ -73,7 +73,6 @@ Add a path (or Git) dependency:
 # Cargo.toml
 [dependencies]
 nyks-wallet = { path = "../nyks-wallet" }           # or github = "twilight-project/nyks-wallet"
-reqwest      = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 ```
 
 Minimal example:

--- a/README.md
+++ b/README.md
@@ -43,16 +43,19 @@ The crate started as a market-maker client and grew into the de-facto wallet lay
 ```
 nyks-wallet
 │
-├── wallet/          # Account handling & on-chain helpers
-│   ├── wallet.rs    # Wallet struct & lifecycle helpers
-│   ├── faucet.rs    # Faucet + BTC-deposit tx builders
-│   ├── nyks_fn.rs   # Mint/Burn trading messages
-│   └── seed_signer.rs
-│
-├── zkos_accounts/   # Shielded account (QuisQuis) utilities
-├── nyks_rpc/        # Minimal JSON-RPC client & message encoder
-├── proto/           # Upstream `.proto` definitions (compiled by build.rs)
-└── src/lib.rs       # Re-exports + generated protobuf modules
+└── src/
+    ├── wallet/          # Account handling & on-chain helpers
+    │   ├── wallet.rs    # Wallet struct & lifecycle helpers
+    │   ├── faucet.rs    # Faucet + BTC-deposit tx builders
+    │   ├── nyks_fn.rs   # Mint/Burn trading messages
+    │   ├── btc_key.rs   # Deterministic BTC key helpers
+    │   └── seed_signer.rs
+    │
+    ├── zkos_accounts/   # Shielded account (QuisQuis) utilities
+    ├── nyks_rpc/        # Minimal JSON-RPC client & message encoder
+    ├── bin/             # CLI utilities (e.g. relayer_init.rs)
+    ├── proto/           # Upstream `.proto` definitions (compiled by build.rs)
+    └── lib.rs           # Re-exports + generated protobuf modules
 ```
 
 All network calls run on **Tokio + Reqwest**, all crypto is handled via **k256**, **curve25519-dalek** and **twilight-client-sdk**.
@@ -132,13 +135,13 @@ All network calls run on **Tokio + Reqwest**, all crypto is handled via **k256**
 
 ## 7 • Environment variables
 
-| Variable            | Default                                | Description                                   |
-| ------------------- | -------------------------------------- | --------------------------------------------- |
-| `NYKS_LCD_BASE_URL` | `https://lcd.twilight.rest`            | Cosmos SDK LCD REST endpoint `port:1317`      |
-| `NYKS_RPC_BASE_URL` | `https://rpc.twilight.rest`            | Cosmos SDK RPC REST endpoint `port:26657`     |
-| `FAUCET_BASE_URL`   | `https://faucet-rpc.twilight.rest`     | Faucet & mint endpoints `port:6969`           |
-| `ZKOS_SERVER_URL`   | `https://nykschain.twilight.rest/zkos` | zkaccount json-rpc endpoint `port:3030`       |
-| `RUST_LOG`          | `info`                                 | `info`, `debug` and `warn` are available tags |
+| Variable            | Default                                                              | Description                                   |
+| ------------------- | -------------------------------------------------------------------- | --------------------------------------------- |
+| `NYKS_LCD_BASE_URL` | `http://0.0.0.0:1317` (public: https://lcd.twilight.rest)            | Cosmos SDK LCD REST endpoint `port:1317`      |
+| `NYKS_RPC_BASE_URL` | `http://0.0.0.0:26657` (public: https://rpc.twilight.rest)           | Cosmos SDK RPC REST endpoint `port:26657`     |
+| `FAUCET_BASE_URL`   | `http://0.0.0.0:6969` (public: https://faucet-rpc.twilight.rest)     | Faucet & mint endpoints `port:6969`           |
+| `ZKOS_SERVER_URL`   | `http://0.0.0.0:3030` (public: https://nykschain.twilight.rest/zkos) | zkaccount json-rpc endpoint `port:3030`       |
+| `RUST_LOG`          | `info`                                                               | `info`, `debug` and `warn` are available tags |
 
 Set them before running to point the SDK at a local full-node.
 
@@ -150,7 +153,6 @@ Set them before running to point the SDK at a local full-node.
 # Cargo.toml
 [dependencies]
 nyks-wallet = { path = "../nyks-wallet" }    # or github = "twilight-project/nyks-wallet"
-reqwest      = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 ```
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -132,12 +132,13 @@ All network calls run on **Tokio + Reqwest**, all crypto is handled via **k256**
 
 ## 7 • Environment variables
 
-| Variable          | Default                                | Description                                   |
-| ----------------- | -------------------------------------- | --------------------------------------------- |
-| `LCD_BASE_URL`    | `https://lcd.twilight.rest`            | Cosmos SDK LCD REST endpoint                  |
-| `FAUCET_BASE_URL` | `https://faucet-rpc.twilight.rest`     | Faucet & mint endpoints                       |
-| `ZKOS_SERVER_URL` | `https://nykschain.twilight.rest/zkos` | zkaccount json-rpc endpoint                   |
-| `RUST_LOG`        | `info`                                 | `info`, `debug` and `warn` are available tags |
+| Variable            | Default                                | Description                                   |
+| ------------------- | -------------------------------------- | --------------------------------------------- |
+| `NYKS_LCD_BASE_URL` | `https://lcd.twilight.rest`            | Cosmos SDK LCD REST endpoint `port:1317`      |
+| `NYKS_RPC_BASE_URL` | `https://rpc.twilight.rest`            | Cosmos SDK RPC REST endpoint `port:26657`     |
+| `FAUCET_BASE_URL`   | `https://faucet-rpc.twilight.rest`     | Faucet & mint endpoints `port:6969`           |
+| `ZKOS_SERVER_URL`   | `https://nykschain.twilight.rest/zkos` | zkaccount json-rpc endpoint `port:3030`       |
+| `RUST_LOG`          | `info`                                 | `info`, `debug` and `warn` are available tags |
 
 Set them before running to point the SDK at a local full-node.
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ async fn main() -> anyhow::Result<()> {
 - [Deployment guide](DEPLOYMENT.md) – detailed steps to build & run `relayer_init` (plus Docker).
 - [`twilight-client-sdk`](https://github.com/twilight-project/twilight-client-sdk) – Rust primitives for QuisQuis & ZkOS.
 - [`relayer-core`](https://github.com/twilight-project/relayer-core) - Twilight Relayer Core is an extremely high performance matching engine written in Rust.
-- [ADR-036](https://github.com/cosmos/cosmos-adrs/blob/main/adr-036-arbitrary-data-signature.md) – Canonical signing of arbitrary data (used by seed signer).
 
 ---
 

--- a/src/bin/relayer_init.rs
+++ b/src/bin/relayer_init.rs
@@ -2,8 +2,8 @@ use log::{debug, error, info};
 use nyks_wallet::{
     nyks_rpc::rpcclient::{
         method::{Method, MethodTypeURL},
-        txrequest::{RpcBody, RpcRequest, TxParams},
-        txresult::{from_rpc_response, parse_tx_response},
+        txrequest::{NYKS_RPC_BASE_URL, RpcBody, RpcRequest, TxParams},
+        txresult::parse_tx_response,
     },
     zkos_accounts::{
         ZkAccount, ZkAccountDB,
@@ -128,7 +128,7 @@ async fn send_rpc_request(signed_tx: String) -> Result<(), String> {
         RpcRequest::new_with_data(TxParams::new(signed_tx.clone()), method, signed_tx);
 
     // RPC endpoint URL (consider moving to an env var later)
-    let url = "https://rpc.twilight.rest".to_string();
+    let url = NYKS_RPC_BASE_URL.to_string();
 
     // Execute the blocking HTTP request on a separate thread
     let response = tokio::task::spawn_blocking(move || tx_send.send(url))

--- a/src/nyks_rpc/rpcclient/txrequest.rs
+++ b/src/nyks_rpc/rpcclient/txrequest.rs
@@ -15,9 +15,11 @@ use std::io::prelude::*;
 // use crate::nyks_rpc::rpcclient::method::ByteRec;
 lazy_static! {
     pub static ref FAUCET_BASE_URL: String =
-        std::env::var("FAUCET_BASE_URL").expect("missing environment variable FAUCET_BASE_URL");
-    pub static ref LCD_BASE_URL: String =
-        std::env::var("LCD_BASE_URL").expect("missing environment variable LCD_BASE_URL");
+        std::env::var("FAUCET_BASE_URL").unwrap_or("http://0.0.0.0:6969".to_string());
+    pub static ref NYKS_LCD_BASE_URL: String =
+        std::env::var("NYKS_LCD_BASE_URL").unwrap_or("http://0.0.0.0:1317".to_string());
+    pub static ref NYKS_RPC_BASE_URL: String =
+        std::env::var("NYKS_RPC_BASE_URL").unwrap_or("http://0.0.0.0:26657".to_string());
 }
 
 fn construct_headers() -> HeaderMap {

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,7 +3,7 @@
 mod tests {
     use crate::nyks_fn::MsgMintBurnTradingBtc;
     use crate::nyks_rpc::rpcclient::method::{Method, MethodTypeURL};
-    use crate::nyks_rpc::rpcclient::txrequest::{RpcBody, RpcRequest, TxParams};
+    use crate::nyks_rpc::rpcclient::txrequest::{NYKS_RPC_BASE_URL, RpcBody, RpcRequest, TxParams};
     use crate::nyks_rpc::rpcclient::txresult::from_rpc_response;
     use crate::seed_signer::{build_sign_doc, sign_adr036, signature_bundle};
     use crate::wallet::*;
@@ -207,8 +207,7 @@ mod tests {
         );
 
         // Send RPC request
-        // let response = tx_send.send("https://rpc.twilight.rest".to_string(), data);
-        let url = "https://rpc.twilight.rest".to_string();
+        let url = NYKS_RPC_BASE_URL.to_string();
         let response = match tokio::task::spawn_blocking(move || tx_send.send(url))
             .await // wait for the blocking task to finish
             {

--- a/src/wallet/nyks_fn.rs
+++ b/src/wallet/nyks_fn.rs
@@ -1,3 +1,5 @@
+use crate::nyks_rpc::rpcclient::txrequest::NYKS_RPC_BASE_URL;
+
 pub use super::super::MsgMintBurnTradingBtc;
 use super::faucet::fetch_account_details;
 use super::wallet::*;
@@ -85,7 +87,7 @@ pub async fn send_tx(msg: MsgMintBurnTradingBtc) -> anyhow::Result<()> {
     let client = reqwest::Client::new();
     let clint_clone = client.clone();
     let res = clint_clone
-        .post("https://rpc.twilight.rest")
+        .post(NYKS_RPC_BASE_URL.as_str())
         .headers(construct_headers())
         .body(tx)
         .send();

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -1,4 +1,5 @@
 use crate::faucet::*;
+use crate::nyks_rpc::rpcclient::txrequest::NYKS_LCD_BASE_URL;
 use anyhow::anyhow;
 use bip32::{DerivationPath, XPrv};
 use bip39::{Error as Bip39Error, Language as B39Lang, Mnemonic};
@@ -213,8 +214,11 @@ pub async fn check_code() -> anyhow::Result<()> {
 }
 
 pub async fn check_balance(address: &str) -> anyhow::Result<Balance> {
-    let baseurl = std::env::var("LCD_BASE_URL").unwrap_or("https://lcd.twilight.rest".to_string());
-    let url = format!("{}/cosmos/bank/v1beta1/balances/{}", baseurl, address);
+    let url = format!(
+        "{}/cosmos/bank/v1beta1/balances/{}",
+        NYKS_LCD_BASE_URL.as_str(),
+        address
+    );
     let client = Client::new();
     let response = client.get(url).send().await?;
     let balance: Value = response.json().await?;
@@ -473,7 +477,8 @@ impl Wallet {
         Ok(self.signing_key()?.public_key())
     }
     pub async fn update_balance(&mut self) -> anyhow::Result<Balance> {
-        let baseurl = std::env::var("LCD_BASE_URL").unwrap_or("http://0.0.0.0:1317".to_string());
+        let baseurl =
+            std::env::var("NYKS_LCD_BASE_URL").unwrap_or("http://0.0.0.0:1317".to_string());
         let url = format!(
             "{}/cosmos/bank/v1beta1/balances/{}",
             baseurl, self.twilightaddress


### PR DESCRIPTION
This pull request updates the environment variable names and refactors endpoint usage across the codebase to support the relayer deployment. Key changes include:

- Introduced new environment variables: NYKS_LCD_BASE_URL and NYKS_RPC_BASE_URL, replacing previous uses of LCD_BASE_URL and hardcoded RPC URLs.
- Updated .env.example, documentation (DEPLOYMENT.md, QuickStart.md, README.md), and all relevant Rust source files to use the new environment variables.
- Refactored endpoint usage in the relayer-init binary, wallet, faucet, and related modules for improved configurability and clarity.
- Updated Docker and build instructions to align with the new environment variable scheme.
- Added bitcoin dependency in Cargo.toml with relevant features.

These changes improve configuration flexibility, make deployment easier, and centralize endpoint management for both developers and users.