### PR TITLE
Enhance relayer-cli: auth, portfolio tracking, and order management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ uuid = { version = "1.6.1", features = ["v4", "serde"] }
 zeroize = "1.7"
 aes-gcm = "0.10"
 clap = { version = "4", features = ["derive"] }
+libc = "0.2"
 
 # ---- Database (feature-gated) ----------------------------------------------
 diesel = { version = "2.1", features = ["chrono", "r2d2"], optional = true }

--- a/docs/relayer-cli.md
+++ b/docs/relayer-cli.md
@@ -340,6 +340,21 @@ Query the status of a trader order. Outputs JSON.
 relayer-cli order query-trade --account-index 0
 ```
 
+### `order unlock-trade`
+
+Unlock a settled trader order. Use this to reclaim a ZkOS account after an SLTP (stop-loss/take-profit) order has been settled by the relayer. If the order is not yet settled, no changes are made.
+
+```bash
+relayer-cli order unlock-trade --account-index 0
+relayer-cli order unlock-trade --account-index 0 --wallet-id my-wallet --password s3cret
+```
+
+| Flag                  | Description                            |
+| --------------------- | -------------------------------------- |
+| `--account-index <N>` | **Required.** ZkOS account index       |
+| `--wallet-id <ID>`    | Load wallet from DB                    |
+| `--password <PASS>`   | DB encryption password                 |
+
 ### `order open-lend`
 
 Open a lending order on a ZkOS account.

--- a/docs/relayer-cli.md
+++ b/docs/relayer-cli.md
@@ -42,10 +42,11 @@ Most commands accept `--wallet-id` and `--password` flags. When omitted, the CLI
 relayer-cli <COMMAND>
 ```
 
-Five top-level command groups:
+Six top-level command groups:
 
 - `wallet` — create, import, load, list, export, backup, restore, unlock/lock wallets
-- `order` — fund accounts, trade, lend, split, withdraw
+- `zkaccount` — fund, withdraw, transfer, and split ZkOS trading accounts
+- `order` — open/close/cancel/query trader and lend orders
 - `market` — query prices, orderbook, rates
 - `history` — view order and transfer history (requires DB)
 - `portfolio` — portfolio summary, balances, liquidation risks
@@ -221,59 +222,67 @@ relayer-cli wallet lock
 
 ---
 
-## Order Commands
+## ZkOS Account Commands
 
-All order commands require `--wallet-id` (or the `NYKS_WALLET_ID` env var) to identify which wallet to use. `--password` falls back to `NYKS_WALLET_PASSPHRASE` env var or the session cache set by `wallet unlock`.
+Manage ZkOS trading accounts — fund from on-chain, withdraw back, transfer between accounts, or split into multiple accounts.
 
-### `order fund`
+All zkaccount commands require `--wallet-id` (or the `NYKS_WALLET_ID` env var) to identify which wallet to use. `--password` falls back to `NYKS_WALLET_PASSPHRASE` env var or the session cache set by `wallet unlock`.
+
+### `zkaccount fund`
 
 Fund a new ZkOS trading account from the on-chain wallet.
 
 ```bash
-relayer-cli order fund --amount 100000
-relayer-cli order fund --amount 100000 --wallet-id my-wallet --password s3cret
+relayer-cli zkaccount fund --amount 100000
+relayer-cli zkaccount fund --amount 100000 --wallet-id my-wallet --password s3cret
 ```
 
 | Flag              | Description                              |
 | ----------------- | ---------------------------------------- |
 | `--amount <SATS>` | **Required.** Amount in satoshis to fund |
 
-### `order withdraw`
+### `zkaccount withdraw`
 
 Withdraw from a ZkOS trading account back to the on-chain wallet.
 
 ```bash
-relayer-cli order withdraw --account-index 0
+relayer-cli zkaccount withdraw --account-index 0
 ```
 
 | Flag                  | Description                                       |
 | --------------------- | ------------------------------------------------- |
 | `--account-index <N>` | **Required.** ZkOS account index to withdraw from |
 
-### `order transfer`
+### `zkaccount transfer`
 
 Transfer funds between ZkOS trading accounts (creates a new destination account).
 
 ```bash
-relayer-cli order transfer --from 0
+relayer-cli zkaccount transfer --from 0
 ```
 
-| Flag         | Description                        |
-| ------------ | ---------------------------------- |
+| Flag         | Description                       |
+| ------------ | --------------------------------- |
 | `--from <N>` | **Required.** Source account index |
 
-### `order split`
+### `zkaccount split`
 
 Split a ZkOS trading account into multiple new accounts with specified balances.
 
 ```bash
-relayer-cli order split --from 0 --balances "1000,2000,3000"
+relayer-cli zkaccount split --from 0 --balances "1000,2000,3000"
 ```
 
 | Flag                | Description                                                                     |
 | ------------------- | ------------------------------------------------------------------------------- |
 | `--from <N>`        | **Required.** Source account index                                              |
 | `--balances <LIST>` | **Required.** Comma-separated list of balances in satoshis for the new accounts |
+
+---
+
+## Order Commands
+
+Trading and lending order commands. All order commands require `--wallet-id` (or the `NYKS_WALLET_ID` env var) to identify which wallet to use. `--password` falls back to `NYKS_WALLET_PASSPHRASE` env var or the session cache set by `wallet unlock`.
 
 ### `order open-trade`
 
@@ -511,6 +520,46 @@ Get lending pool information. Outputs JSON.
 
 ```bash
 relayer-cli market lend-pool
+```
+
+### `market pool-share-value`
+
+Get the current pool share value.
+
+```bash
+relayer-cli market pool-share-value
+```
+
+### `market last-day-apy`
+
+Get the annualized percentage yield (APY) for the last 24 hours.
+
+```bash
+relayer-cli market last-day-apy
+```
+
+### `market open-interest`
+
+Get current open interest showing long and short exposure in BTC.
+
+```bash
+relayer-cli market open-interest
+```
+
+### `market market-stats`
+
+Get comprehensive market risk statistics including pool equity, exposure, utilization, and risk parameters.
+
+```bash
+relayer-cli market market-stats
+```
+
+### `market server-time`
+
+Get the relayer server's current UTC time.
+
+```bash
+relayer-cli market server-time
 ```
 
 ---

--- a/docs/relayer-cli.md
+++ b/docs/relayer-cli.md
@@ -18,14 +18,23 @@ The binary will be at `target/release/relayer-cli`.
 
 ## Environment Variables
 
-| Variable | Description | Default |
-|---|---|---|
-| `RELAYER_API_RPC_SERVER_URL` | Relayer JSON-RPC endpoint | `http://0.0.0.0:8088/api` |
-| `NYKS_WALLET_PASSPHRASE` | Database encryption password (fallback when `--password` is omitted) | — |
-| `DATABASE_URL_SQLITE` | SQLite database file path | `./wallet_data.db` |
-| `DATABASE_URL_POSTGRESQL` | PostgreSQL connection string (when using `postgresql` feature) | — |
+| Variable                     | Description                                                          | Default                   |
+| ---------------------------- | -------------------------------------------------------------------- | ------------------------- |
+| `NYKS_WALLET_ID`             | Default wallet ID (fallback when `--wallet-id` is omitted)           | —                         |
+| `NYKS_WALLET_PASSPHRASE`     | Database encryption password (fallback when `--password` is omitted) | —                         |
+| `RELAYER_API_RPC_SERVER_URL` | Relayer JSON-RPC endpoint                                            | `http://0.0.0.0:8088/api` |
+| `DATABASE_URL_SQLITE`        | SQLite database file path                                            | `./wallet_data.db`        |
+| `DATABASE_URL_POSTGRESQL`    | PostgreSQL connection string (when using `postgresql` feature)       | —                         |
 
 A `.env` file in the working directory is loaded automatically.
+
+## Password and Wallet ID Resolution
+
+Most commands accept `--wallet-id` and `--password` flags. When omitted, the CLI resolves them through a fallback chain:
+
+**Wallet ID:** `--wallet-id` flag → `NYKS_WALLET_ID` env var → error.
+
+**Password:** `--password` flag → `NYKS_WALLET_PASSPHRASE` env var → session cache (see `wallet unlock`) → none.
 
 ## Usage
 
@@ -35,8 +44,8 @@ relayer-cli <COMMAND>
 
 Five top-level command groups:
 
-- `wallet` — create, import, load, list, export, backup, restore wallets
-- `order` — fund accounts, trade, lend, withdraw
+- `wallet` — create, import, load, list, export, backup, restore, unlock/lock wallets
+- `order` — fund accounts, trade, lend, split, withdraw
 - `market` — query prices, orderbook, rates
 - `history` — view order and transfer history (requires DB)
 - `portfolio` — portfolio summary, balances, liquidation risks
@@ -56,11 +65,11 @@ relayer-cli wallet create
 relayer-cli wallet create --with-db --wallet-id my-wallet --password s3cret
 ```
 
-| Flag | Description |
-|---|---|
-| `--wallet-id <ID>` | Optional ID for DB storage (defaults to the Twilight address) |
-| `--password <PASS>` | DB encryption password |
-| `--with-db` | Enable database persistence |
+| Flag                | Description                                                   |
+| ------------------- | ------------------------------------------------------------- |
+| `--wallet-id <ID>`  | Optional ID for DB storage (defaults to the Twilight address) |
+| `--password <PASS>` | DB encryption password                                        |
+| `--with-db`         | Enable database persistence                                   |
 
 ### `wallet import`
 
@@ -70,15 +79,15 @@ Restore a wallet from a BIP-39 mnemonic.
 relayer-cli wallet import --mnemonic "word1 word2 ... word24"
 
 # With DB persistence
-relayer-cli wallet import --mnemonic "..." --with-db --wallet-id restored --password s3cret
+relayer-cli wallet import --mnemonic "..." --with-db --wallet-id restored_wallet_id --password s3cret
 ```
 
-| Flag | Description |
-|---|---|
+| Flag                  | Description                           |
+| --------------------- | ------------------------------------- |
 | `--mnemonic <PHRASE>` | **Required.** 24-word BIP-39 mnemonic |
-| `--wallet-id <ID>` | Optional DB wallet ID |
-| `--password <PASS>` | DB encryption password |
-| `--with-db` | Enable database persistence |
+| `--wallet-id <ID>`    | Optional DB wallet ID                 |
+| `--password <PASS>`   | DB encryption password                |
+| `--with-db`           | Enable database persistence           |
 
 ### `wallet load`
 
@@ -88,11 +97,11 @@ Load a wallet from the database. Requires `sqlite` or `postgresql` feature.
 relayer-cli wallet load --wallet-id my-wallet --password s3cret
 ```
 
-| Flag | Description |
-|---|---|
-| `--wallet-id <ID>` | **Required.** Wallet ID in the database |
-| `--password <PASS>` | DB encryption password |
-| `--db-url <URL>` | Override the default database URL |
+| Flag                | Description                             |
+| ------------------- | --------------------------------------- |
+| `--wallet-id <ID>`  | **Required.** Wallet ID in the database |
+| `--password <PASS>` | DB encryption password                  |
+| `--db-url <URL>`    | Override the default database URL       |
 
 ### `wallet balance`
 
@@ -121,20 +130,29 @@ relayer-cli wallet export --output wallet-backup.json
 relayer-cli wallet export --wallet-id my-wallet --password s3cret
 ```
 
-| Flag | Description |
-|---|---|
-| `--output <PATH>` | Output file path (default: `wallet.json`) |
-| `--wallet-id <ID>` | Load wallet from DB |
-| `--password <PASS>` | DB encryption password |
+| Flag                | Description                               |
+| ------------------- | ----------------------------------------- |
+| `--output <PATH>`   | Output file path (default: `wallet.json`) |
+| `--wallet-id <ID>`  | Load wallet from DB                       |
+| `--password <PASS>` | DB encryption password                    |
 
 ### `wallet accounts`
 
-List all ZkOS trading accounts associated with a wallet.
+List all ZkOS trading accounts associated with a wallet, sorted by account index.
 
 ```bash
 relayer-cli wallet accounts
 relayer-cli wallet accounts --wallet-id my-wallet --password s3cret
+
+# Only show accounts that are on-chain (hide off-chain accounts)
+relayer-cli wallet accounts --on-chain-only
 ```
+
+| Flag                | Description                               |
+| ------------------- | ----------------------------------------- |
+| `--wallet-id <ID>`  | Load wallet from DB                       |
+| `--password <PASS>` | DB encryption password                    |
+| `--on-chain-only`   | Only show accounts where on-chain is true |
 
 Output columns: `INDEX`, `BALANCE`, `ON-CHAIN`, `IO-TYPE`, `ACCOUNT`.
 
@@ -147,11 +165,11 @@ relayer-cli wallet backup --wallet-id my-wallet --password s3cret
 relayer-cli wallet backup --wallet-id my-wallet --password s3cret --output my-backup.json
 ```
 
-| Flag | Description |
-|---|---|
-| `--wallet-id <ID>` | **Required.** Wallet ID to back up |
-| `--password <PASS>` | DB encryption password |
-| `--output <PATH>` | Output file path (default: `wallet_backup.json`) |
+| Flag                | Description                                      |
+| ------------------- | ------------------------------------------------ |
+| `--wallet-id <ID>`  | **Required.** Wallet ID to back up               |
+| `--password <PASS>` | DB encryption password                           |
+| `--output <PATH>`   | Output file path (default: `wallet_backup.json`) |
 
 ### `wallet restore`
 
@@ -164,12 +182,12 @@ relayer-cli wallet restore --wallet-id my-wallet --password s3cret --input my-ba
 relayer-cli wallet restore --wallet-id new-wallet --password s3cret --input my-backup.json --force
 ```
 
-| Flag | Description |
-|---|---|
-| `--wallet-id <ID>` | **Required.** Wallet ID to restore into |
-| `--password <PASS>` | DB encryption password |
-| `--input <PATH>` | **Required.** Backup file path |
-| `--force` | Allow restoring even if backup wallet_id doesn't match target |
+| Flag                | Description                                                   |
+| ------------------- | ------------------------------------------------------------- |
+| `--wallet-id <ID>`  | **Required.** Wallet ID to restore into                       |
+| `--password <PASS>` | DB encryption password                                        |
+| `--input <PATH>`    | **Required.** Backup file path                                |
+| `--force`           | Allow restoring even if backup wallet_id doesn't match target |
 
 ### `wallet sync-nonce`
 
@@ -181,11 +199,31 @@ relayer-cli wallet sync-nonce --wallet-id my-wallet --password s3cret
 
 Output shows the next sequence number, cached account number, and count of released (reclaimable) sequences.
 
+### `wallet unlock`
+
+Prompt for the database password once and cache it for the current terminal session. Subsequent commands in the same shell will use the cached password automatically, so you don't need to pass `--password` each time.
+
+The cache is scoped to the parent shell process — closing the terminal invalidates it. Only one session password can be active at a time; run `wallet lock` first to replace it.
+
+```bash
+relayer-cli wallet unlock
+# Enter password at the secure prompt, then:
+relayer-cli wallet balance --wallet-id my-wallet   # no --password needed
+```
+
+### `wallet lock`
+
+Clear the cached session password immediately.
+
+```bash
+relayer-cli wallet lock
+```
+
 ---
 
 ## Order Commands
 
-All order commands accept `--wallet-id` and `--password` to load a persisted wallet. Without these flags, a fresh in-memory wallet is created.
+All order commands require `--wallet-id` (or the `NYKS_WALLET_ID` env var) to identify which wallet to use. `--password` falls back to `NYKS_WALLET_PASSPHRASE` env var or the session cache set by `wallet unlock`.
 
 ### `order fund`
 
@@ -196,8 +234,8 @@ relayer-cli order fund --amount 100000
 relayer-cli order fund --amount 100000 --wallet-id my-wallet --password s3cret
 ```
 
-| Flag | Description |
-|---|---|
+| Flag              | Description                              |
+| ----------------- | ---------------------------------------- |
 | `--amount <SATS>` | **Required.** Amount in satoshis to fund |
 
 ### `order withdraw`
@@ -208,8 +246,8 @@ Withdraw from a ZkOS trading account back to the on-chain wallet.
 relayer-cli order withdraw --account-index 0
 ```
 
-| Flag | Description |
-|---|---|
+| Flag                  | Description                                       |
+| --------------------- | ------------------------------------------------- |
 | `--account-index <N>` | **Required.** ZkOS account index to withdraw from |
 
 ### `order transfer`
@@ -220,9 +258,22 @@ Transfer funds between ZkOS trading accounts (creates a new destination account)
 relayer-cli order transfer --from 0
 ```
 
-| Flag | Description |
-|---|---|
+| Flag         | Description                        |
+| ------------ | ---------------------------------- |
 | `--from <N>` | **Required.** Source account index |
+
+### `order split`
+
+Split a ZkOS trading account into multiple new accounts with specified balances.
+
+```bash
+relayer-cli order split --from 0 --balances "1000,2000,3000"
+```
+
+| Flag                | Description                                                                     |
+| ------------------- | ------------------------------------------------------------------------------- |
+| `--from <N>`        | **Required.** Source account index                                              |
+| `--balances <LIST>` | **Required.** Comma-separated list of balances in satoshis for the new accounts |
 
 ### `order open-trade`
 
@@ -236,13 +287,13 @@ relayer-cli order open-trade --account-index 0 --side LONG --entry-price 65000 -
 relayer-cli order open-trade --account-index 1 --order-type LIMIT --side SHORT --entry-price 70000 --leverage 5
 ```
 
-| Flag | Description |
-|---|---|
-| `--account-index <N>` | **Required.** ZkOS account index |
-| `--side <LONG\|SHORT>` | **Required.** Position direction |
-| `--entry-price <USD>` | **Required.** Entry price in USD (integer) |
-| `--leverage <1-50>` | **Required.** Leverage multiplier |
-| `--order-type <TYPE>` | `MARKET` (default) or `LIMIT` |
+| Flag                   | Description                                |
+| ---------------------- | ------------------------------------------ |
+| `--account-index <N>`  | **Required.** ZkOS account index           |
+| `--side <LONG\|SHORT>` | **Required.** Position direction           |
+| `--entry-price <USD>`  | **Required.** Entry price in USD (integer) |
+| `--leverage <1-50>`    | **Required.** Leverage multiplier          |
+| `--order-type <TYPE>`  | `MARKET` (default) or `LIMIT`              |
 
 ### `order close-trade`
 
@@ -256,13 +307,13 @@ relayer-cli order close-trade --account-index 0
 relayer-cli order close-trade --account-index 0 --stop-loss 60000 --take-profit 75000
 ```
 
-| Flag | Description |
-|---|---|
-| `--account-index <N>` | **Required.** ZkOS account index |
-| `--order-type <TYPE>` | `MARKET` (default) or `LIMIT` |
+| Flag                    | Description                                 |
+| ----------------------- | ------------------------------------------- |
+| `--account-index <N>`   | **Required.** ZkOS account index            |
+| `--order-type <TYPE>`   | `MARKET` (default) or `LIMIT`               |
 | `--execution-price <F>` | Execution price (default: `0.0` for market) |
-| `--stop-loss <F>` | Stop-loss price (triggers SLTP close) |
-| `--take-profit <F>` | Take-profit price (triggers SLTP close) |
+| `--stop-loss <F>`       | Stop-loss price (triggers SLTP close)       |
+| `--take-profit <F>`     | Take-profit price (triggers SLTP close)     |
 
 ### `order cancel-trade`
 
@@ -324,13 +375,13 @@ relayer-cli history orders --wallet-id my-wallet --password s3cret --account-ind
 relayer-cli history orders --wallet-id my-wallet --password s3cret --limit 20 --offset 40
 ```
 
-| Flag | Description |
-|---|---|
-| `--wallet-id <ID>` | **Required.** Wallet ID |
-| `--password <PASS>` | DB encryption password |
+| Flag                  | Description                        |
+| --------------------- | ---------------------------------- |
+| `--wallet-id <ID>`    | **Required.** Wallet ID            |
+| `--password <PASS>`   | DB encryption password             |
 | `--account-index <N>` | Filter to a specific account index |
-| `--limit <N>` | Max results (default: `50`) |
-| `--offset <N>` | Pagination offset (default: `0`) |
+| `--limit <N>`         | Max results (default: `50`)        |
+| `--offset <N>`        | Pagination offset (default: `0`)   |
 
 Output columns: `ACCT`, `ACTION`, `TYPE`, `SIDE`, `AMOUNT`, `PRICE`, `STATUS`, `CREATED`.
 
@@ -343,14 +394,14 @@ relayer-cli history transfers --wallet-id my-wallet --password s3cret
 relayer-cli history transfers --wallet-id my-wallet --password s3cret --limit 10
 ```
 
-| Flag | Description |
-|---|---|
-| `--wallet-id <ID>` | **Required.** Wallet ID |
-| `--password <PASS>` | DB encryption password |
-| `--limit <N>` | Max results (default: `50`) |
-| `--offset <N>` | Pagination offset (default: `0`) |
+| Flag                | Description                      |
+| ------------------- | -------------------------------- |
+| `--wallet-id <ID>`  | **Required.** Wallet ID          |
+| `--password <PASS>` | DB encryption password           |
+| `--limit <N>`       | Max results (default: `50`)      |
+| `--offset <N>`      | Pagination offset (default: `0`) |
 
-Output columns: `DIRECTION`, `FROM`, `TO`, `AMOUNT`, `TX HASH`, `CREATED`.
+Output columns: `DIRECTION`, `FROM`, `TO`, `AMOUNT`, `CREATED`, `TX HASH`.
 
 ---
 
@@ -372,8 +423,8 @@ Output includes:
 - Total margin used and utilization percentage
 - Unrealized PnL across all positions
 - Lend deposits, current value, and lend PnL
-- Per-position table for trader orders (entry/current price, size, leverage, PnL, liquidation price)
-- Per-position table for lend orders (deposit, current value, PnL, pool shares)
+- Per-position table for trader orders (entry/current price, size, leverage, PnL, liquidation price, funding)
+- Per-position table for lend orders (deposit, current value, PnL, unrealised PnL, APR, pool shares)
 
 ### `portfolio balances`
 

--- a/docs/relayer-cli.md
+++ b/docs/relayer-cli.md
@@ -443,12 +443,18 @@ relayer-cli portfolio summary --wallet-id my-wallet --password s3cret
 ```
 
 Output includes:
-- On-chain and trading balances
+- Mark price, on-chain and trading balances
 - Total margin used and utilization percentage
-- Unrealized PnL across all positions
+- Unrealized PnL across open positions (excludes PENDING orders)
+- Realised PnL from settled positions
+- Liquidation loss from liquidated positions
 - Lend deposits, current value, and lend PnL
-- Per-position table for trader orders (entry/current price, size, leverage, PnL, liquidation price, funding)
-- Per-position table for lend orders (deposit, current value, PnL, unrealised PnL, APR, pool shares)
+- **Trader Positions** table: `ACCT`, `STATUS`, `SIDE`, `ENTRY`, `SIZE`, `LEV`, `A.MARGIN`, `U_PnL`, `LIQ PRICE`, `FEE`, `FUNDING`, `LIMIT`, `TP`, `SL`
+- **Closed Positions** table (settled & unlocked): `ACCT`, `SIDE`, `ENTRY`, `SIZE`, `LEV`, `A.MARGIN`, `R_PnL`, `NET_PnL`, `FEE_FILL`, `FEE_SETT`, `FUNDING`, plus total realised PnL
+- **Liquidated Positions** table: `ACCT`, `SIDE`, `ENTRY`, `SIZE`, `LEV`, `I.MARGIN`, `FEE_FILL`, `FEE_SETT`, plus total liquidation loss
+- **Lend Positions** table: `ACCT`, `DEPOSIT`, `VALUE`, `PnL`, `uPnL`, `APR %`, `SHARES`
+
+Settled and liquidated accounts are automatically unlocked (restored to Coin state) when the summary is generated.
 
 ### `portfolio balances`
 

--- a/src/bin/relayer_cli.rs
+++ b/src/bin/relayer_cli.rs
@@ -369,6 +369,21 @@ enum OrderCmd {
         password: Option<String>,
     },
 
+    /// Unlock a settled trader order (reclaim account after SLTP settlement)
+    UnlockTrade {
+        /// ZkOS account index
+        #[arg(long)]
+        account_index: u64,
+
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
+        #[arg(long)]
+        wallet_id: Option<String>,
+
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
+        #[arg(long)]
+        password: Option<String>,
+    },
+
     /// Open a lend order
     OpenLend {
         /// ZkOS account index to lend from
@@ -1267,6 +1282,31 @@ async fn handle_order(cmd: OrderCmd) -> Result<(), String> {
             let request_id = ow.close_lend_order(account_index).await?;
             println!("Lend order closed successfully");
             println!("  Request ID: {request_id}");
+            Ok(())
+        }
+
+        OrderCmd::UnlockTrade {
+            account_index,
+            wallet_id,
+            password,
+        } => {
+            #[cfg(any(feature = "sqlite", feature = "postgresql"))]
+            let mut ow = resolve_order_wallet(wallet_id, password).await?;
+            #[cfg(not(any(feature = "sqlite", feature = "postgresql")))]
+            let mut ow = OrderWallet::new(None).map_err(|e| e.to_string())?;
+
+            let status = ow.unlock_settled_order(account_index).await?;
+            match status {
+                OrderStatus::SETTLED => {
+                    println!("Account {} unlocked successfully (order settled).", account_index);
+                }
+                _ => {
+                    println!(
+                        "Account {} not yet settled (current status: {:?}). No changes made.",
+                        account_index, status
+                    );
+                }
+            }
             Ok(())
         }
 

--- a/src/bin/relayer_cli.rs
+++ b/src/bin/relayer_cli.rs
@@ -1472,6 +1472,7 @@ async fn handle_portfolio(cmd: PortfolioCmd) -> Result<(), String> {
             );
             println!("  Margin used:         {:.2}", portfolio.total_margin_used);
             println!("  Unrealized PnL:      {:.2}", portfolio.unrealized_pnl);
+            println!("  Realised PnL:        {:.2}", portfolio.realised_pnl);
             println!(
                 "  Margin utilization:  {:.2}%",
                 portfolio.margin_utilization * 100.0
@@ -1544,6 +1545,40 @@ async fn handle_portfolio(cmd: PortfolioCmd) -> Result<(), String> {
                         sl_str,
                     );
                 }
+            }
+
+            if !portfolio.closed_trader_positions.is_empty() {
+                println!("\nClosed Positions (Settled & Unlocked)");
+                println!("{}", "-".repeat(100));
+                println!(
+                    "  {:<6} {:<6} {:>12} {:>16} {:>6} {:>10} {:>12} {:>12} {:>10} {:>10} {:>10}",
+                    "ACCT", "SIDE", "ENTRY", "SIZE", "LEV", "A.MARGIN", "R_PnL", "NET_PnL", "FEE_FILL", "FEE_SETT", "FUNDING"
+                );
+                for p in &portfolio.closed_trader_positions {
+                    let funding_str = p
+                        .funding_applied
+                        .map(|v| format!("{:.4}", v))
+                        .unwrap_or_else(|| "-".to_string());
+                    let net_pnl = p.available_margin - p.initial_margin;
+                    println!(
+                        "  {:<6} {:<6} {:>12.2} {:>16.2} {:>5.0}x {:>10.2} {:>12.2} {:>12.2} {:>10.4} {:>10.4} {:>10}",
+                        p.account_index,
+                        format!("{:?}", p.position_type),
+                        p.entry_price,
+                        p.position_size,
+                        p.leverage,
+                        p.available_margin,
+                        p.unrealized_pnl,
+                        net_pnl,
+                        p.fee_filled,
+                        p.fee_settled,
+                        funding_str,
+                    );
+                }
+                println!(
+                    "\n  Total Realised PnL: {:.2}",
+                    portfolio.realised_pnl
+                );
             }
 
             if !portfolio.lend_positions.is_empty() {

--- a/src/bin/relayer_cli.rs
+++ b/src/bin/relayer_cli.rs
@@ -95,11 +95,11 @@ enum WalletCmd {
 
     /// Show wallet balance and account info
     Balance {
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -117,22 +117,22 @@ enum WalletCmd {
         #[arg(long, default_value = "wallet.json")]
         output: String,
 
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
 
     /// List all ZkOS accounts for a wallet
     Accounts {
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -173,11 +173,11 @@ enum WalletCmd {
 
     /// Sync the nonce/sequence manager from chain state
     SyncNonce {
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -195,11 +195,11 @@ enum OrderCmd {
         #[arg(long)]
         amount: u64,
 
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -210,11 +210,11 @@ enum OrderCmd {
         #[arg(long)]
         account_index: u64,
 
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -225,11 +225,11 @@ enum OrderCmd {
         #[arg(long)]
         from: u64,
 
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -256,11 +256,11 @@ enum OrderCmd {
         #[arg(long)]
         leverage: u64,
 
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -287,11 +287,11 @@ enum OrderCmd {
         #[arg(long)]
         take_profit: Option<f64>,
 
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -302,11 +302,11 @@ enum OrderCmd {
         #[arg(long)]
         account_index: u64,
 
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -317,11 +317,11 @@ enum OrderCmd {
         #[arg(long)]
         account_index: u64,
 
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -332,11 +332,11 @@ enum OrderCmd {
         #[arg(long)]
         account_index: u64,
 
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -347,11 +347,11 @@ enum OrderCmd {
         #[arg(long)]
         account_index: u64,
 
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -362,11 +362,11 @@ enum OrderCmd {
         #[arg(long)]
         account_index: u64,
 
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -380,11 +380,11 @@ enum OrderCmd {
 enum HistoryCmd {
     /// Show order history (open, close, cancel events)
     Orders {
-        /// Wallet ID (required, loads from DB)
+        /// Wallet ID (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
-        wallet_id: String,
+        wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
 
@@ -403,11 +403,11 @@ enum HistoryCmd {
 
     /// Show transfer history (fund, withdraw, transfer events)
     Transfers {
-        /// Wallet ID (required, loads from DB)
+        /// Wallet ID (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
-        wallet_id: String,
+        wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
 
@@ -429,33 +429,33 @@ enum HistoryCmd {
 enum PortfolioCmd {
     /// Show full portfolio summary (balances, positions, PnL)
     Summary {
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
 
     /// Show per-account balance breakdown
     Balances {
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
 
     /// Show liquidation risk for open positions
     Risks {
-        /// Load wallet from DB by wallet ID
+        /// Wallet ID to load from DB (falls back to NYKS_WALLET_ID env var)
         #[arg(long)]
         wallet_id: Option<String>,
 
-        /// Database encryption password
+        /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
     },
@@ -512,25 +512,40 @@ fn parse_position_type(
     }
 }
 
-/// Build an `OrderWallet` either from DB or by creating a new one (caller decides).
+/// Build an `OrderWallet` from DB. Password falls back to `NYKS_WALLET_PASSPHRASE` env var.
 #[cfg(any(feature = "sqlite", feature = "postgresql"))]
 fn load_order_wallet_from_db(
     wallet_id: &str,
     password: Option<String>,
     db_url: Option<String>,
 ) -> Result<OrderWallet, String> {
-    let pwd = password.map(|p| SecretString::new(p.into()));
+    let pwd = resolve_password(password).map(|p| SecretString::new(p.into()));
     OrderWallet::load_from_db(wallet_id.to_string(), pwd, db_url)
 }
 
-/// Resolve an `OrderWallet` – either load from DB (if wallet_id given) or create fresh.
+/// Resolve password: CLI arg → `NYKS_WALLET_PASSPHRASE` env var → None.
+fn resolve_password(password: Option<String>) -> Option<String> {
+    password.or_else(|| std::env::var("NYKS_WALLET_PASSPHRASE").ok())
+}
+
+/// Resolve wallet_id: CLI arg → `NYKS_WALLET_ID` env var → None.
+fn resolve_wallet_id(wallet_id: Option<String>) -> Option<String> {
+    wallet_id.or_else(|| std::env::var("NYKS_WALLET_ID").ok())
+}
+
+/// Resolve an `OrderWallet` – load from DB using wallet_id (arg or env), or create fresh.
+///
+/// Priority: CLI arg → `NYKS_WALLET_ID` env var → create a new ephemeral wallet.
+/// Password priority: CLI arg → `NYKS_WALLET_PASSPHRASE` env var.
 #[cfg(any(feature = "sqlite", feature = "postgresql"))]
 async fn resolve_order_wallet(
     wallet_id: Option<String>,
     password: Option<String>,
 ) -> Result<OrderWallet, String> {
-    if let Some(wid) = wallet_id {
-        load_order_wallet_from_db(&wid, password, None)
+    let wid = resolve_wallet_id(wallet_id);
+    let pwd = resolve_password(password);
+    if let Some(wid) = wid {
+        load_order_wallet_from_db(&wid, pwd, None)
     } else {
         OrderWallet::new(None).map_err(|e| e.to_string())
     }
@@ -1013,6 +1028,8 @@ async fn handle_history(cmd: HistoryCmd) -> Result<(), String> {
             limit,
             offset,
         } => {
+            let wallet_id = resolve_wallet_id(wallet_id)
+                .ok_or("wallet_id is required (pass --wallet-id or set NYKS_WALLET_ID)")?;
             let ow = load_order_wallet_from_db(&wallet_id, password, None)?;
             let filter = nyks_wallet::relayer_module::transaction_history::OrderHistoryFilter {
                 account_index,
@@ -1055,6 +1072,8 @@ async fn handle_history(cmd: HistoryCmd) -> Result<(), String> {
             limit,
             offset,
         } => {
+            let wallet_id = resolve_wallet_id(wallet_id)
+                .ok_or("wallet_id is required (pass --wallet-id or set NYKS_WALLET_ID)")?;
             let ow = load_order_wallet_from_db(&wallet_id, password, None)?;
             let filter = nyks_wallet::relayer_module::transaction_history::TransferHistoryFilter {
                 limit: Some(limit),

--- a/src/bin/relayer_cli.rs
+++ b/src/bin/relayer_cli.rs
@@ -181,6 +181,14 @@ enum WalletCmd {
         #[arg(long)]
         password: Option<String>,
     },
+
+    /// Unlock: prompt for password once and cache it for this terminal session.
+    /// Subsequent commands will use the cached password automatically.
+    /// The cache is invalidated when the terminal (shell) is closed.
+    Unlock,
+
+    /// Lock: clear the cached session password immediately.
+    Lock,
 }
 
 // ---------------------------------------------------------------------------
@@ -523,9 +531,122 @@ fn load_order_wallet_from_db(
     OrderWallet::load_from_db(wallet_id.to_string(), pwd, db_url)
 }
 
-/// Resolve password: CLI arg → `NYKS_WALLET_PASSPHRASE` env var → None.
+// ---------------------------------------------------------------------------
+// Session password cache  (~/.cache/nyks-wallet/session-<ppid>)
+// ---------------------------------------------------------------------------
+//
+// The file is named by the *parent* shell's PID.  Before trusting the cached
+// value we verify that PID is still alive via /proc – so when the terminal is
+// closed and the shell exits, subsequent invocations find the parent dead and
+// silently discard the stale file.
+//
+// Security model: the file lives in ~/.cache/nyks-wallet/ (mode 0700) and is
+// itself mode 0600 – the same protection as ~/.ssh/id_rsa.  No other process
+// owned by the same user can read it.
+
+#[cfg(unix)]
+fn get_ppid() -> Option<u32> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("PPid:") {
+            return rest.trim().parse().ok();
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_process_alive(pid: u32) -> bool {
+    std::path::Path::new(&format!("/proc/{pid}")).exists()
+}
+
+fn session_dir() -> Option<std::path::PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    Some(std::path::PathBuf::from(home).join(".cache").join("nyks-wallet"))
+}
+
+#[cfg(unix)]
+fn session_file_path(ppid: u32) -> Option<std::path::PathBuf> {
+    Some(session_dir()?.join(format!("session-{ppid}.lock")))
+}
+
+/// Save password to session cache, bound to the current shell (PPID).
+#[cfg(unix)]
+fn session_save(password: &str) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ppid = get_ppid().ok_or("cannot determine parent shell PID")?;
+    let dir = session_dir().ok_or("cannot determine home directory")?;
+
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+        .map_err(|e| e.to_string())?;
+
+    let path = session_file_path(ppid).ok_or("cannot build session file path")?;
+    let content = format!("{ppid}\n{password}");
+    std::fs::write(&path, content.as_bytes()).map_err(|e| e.to_string())?;
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+/// Load password from session cache; returns None if shell is gone or cache is missing.
+#[cfg(unix)]
+fn session_load() -> Option<String> {
+    let ppid = get_ppid()?;
+    if !is_process_alive(ppid) {
+        session_clear_for(ppid); // clean up stale file
+        return None;
+    }
+    let path = session_file_path(ppid)?;
+    let content = std::fs::read_to_string(&path).ok()?;
+    let (stored, password) = content.split_once('\n')?;
+    if stored.trim().parse::<u32>().ok()? != ppid {
+        return None; // sanity-check: file belongs to this shell
+    }
+    Some(password.to_string())
+}
+
+/// Zeroize and delete the session file for the current shell.
+#[cfg(unix)]
+fn session_clear() {
+    if let Some(ppid) = get_ppid() {
+        session_clear_for(ppid);
+    }
+}
+
+#[cfg(unix)]
+fn session_clear_for(ppid: u32) {
+    if let Some(path) = session_file_path(ppid) {
+        // Overwrite with zeros before unlinking so the content isn't recoverable
+        if let Ok(meta) = std::fs::metadata(&path) {
+            let zeros = vec![0u8; meta.len() as usize];
+            let _ = std::fs::write(&path, &zeros);
+        }
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+// Non-Unix stubs (Windows / wasm – session cache is a no-op there).
+#[cfg(not(unix))]
+fn session_save(_password: &str) -> Result<(), String> {
+    Err("session cache is only supported on Unix".to_string())
+}
+#[cfg(not(unix))]
+fn session_load() -> Option<String> { None }
+#[cfg(not(unix))]
+fn session_clear() {}
+
+// ---------------------------------------------------------------------------
+// Password / wallet-ID resolution helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve password: CLI arg → `NYKS_WALLET_PASSPHRASE` env var → session cache → None.
 fn resolve_password(password: Option<String>) -> Option<String> {
-    password.or_else(|| std::env::var("NYKS_WALLET_PASSPHRASE").ok())
+    password
+        .or_else(|| std::env::var("NYKS_WALLET_PASSPHRASE").ok())
+        .or_else(session_load)
 }
 
 /// Resolve wallet_id: CLI arg → `NYKS_WALLET_ID` env var → None.
@@ -789,6 +910,29 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
             println!("  Next sequence: {}", ow.nonce_manager.peek_next());
             println!("  Account number: {}", ow.nonce_manager.account_number());
             println!("  Released (pending reuse): {}", ow.nonce_manager.released_count());
+            Ok(())
+        }
+
+        WalletCmd::Unlock => {
+            // If a session is already active, ask before overwriting.
+            if session_load().is_some() {
+                eprintln!("A session password is already cached. Run `wallet lock` first to clear it.");
+                return Err("session already active".to_string());
+            }
+            let password = rpassword::prompt_password("Wallet password: ")
+                .map_err(|e| e.to_string())?;
+            if password.is_empty() {
+                return Err("password must not be empty".to_string());
+            }
+            session_save(&password)?;
+            println!("Password cached for this terminal session.");
+            println!("Run `wallet lock` to clear it, or just close the terminal.");
+            Ok(())
+        }
+
+        WalletCmd::Lock => {
+            session_clear();
+            println!("Session password cleared.");
             Ok(())
         }
     }

--- a/src/bin/relayer_cli.rs
+++ b/src/bin/relayer_cli.rs
@@ -135,6 +135,10 @@ enum WalletCmd {
         /// Database encryption password (falls back to NYKS_WALLET_PASSPHRASE env var)
         #[arg(long)]
         password: Option<String>,
+
+        /// Only show on-chain accounts (hide accounts where on_chain is false)
+        #[arg(long, default_value_t = false)]
+        on_chain_only: bool,
     },
 
     /// Export a full database backup to a JSON file (requires DB)
@@ -555,9 +559,9 @@ fn load_order_wallet_from_db(
 // ---------------------------------------------------------------------------
 //
 // The file is named by the *parent* shell's PID.  Before trusting the cached
-// value we verify that PID is still alive via /proc – so when the terminal is
-// closed and the shell exits, subsequent invocations find the parent dead and
-// silently discard the stale file.
+// value we verify that PID is still alive via kill(pid, 0) – so when the
+// terminal is closed and the shell exits, subsequent invocations find the
+// parent dead and silently discard the stale file.
 //
 // Security model: the file lives in ~/.cache/nyks-wallet/ (mode 0700) and is
 // itself mode 0600 – the same protection as ~/.ssh/id_rsa.  No other process
@@ -595,7 +599,8 @@ fn session_file_path(ppid: u32) -> Option<std::path::PathBuf> {
 /// Save password to session cache, bound to the current shell (PPID).
 #[cfg(unix)]
 fn session_save(password: &str) -> Result<(), String> {
-    use std::os::unix::fs::PermissionsExt;
+    use std::io::Write;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
     let ppid = get_ppid().ok_or("cannot determine parent shell PID")?;
     let dir = session_dir().ok_or("cannot determine home directory")?;
@@ -606,9 +611,16 @@ fn session_save(password: &str) -> Result<(), String> {
 
     let path = session_file_path(ppid).ok_or("cannot build session file path")?;
     let content = format!("{ppid}\n{password}");
-    std::fs::write(&path, content.as_bytes()).map_err(|e| e.to_string())?;
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+    // Create with 0o600 atomically to avoid a TOCTOU window where the file
+    // is briefly world-readable under the default umask.
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&path)
         .map_err(|e| e.to_string())?;
+    file.write_all(content.as_bytes()).map_err(|e| e.to_string())?;
 
     Ok(())
 }
@@ -676,22 +688,20 @@ fn resolve_wallet_id(wallet_id: Option<String>) -> Option<String> {
     wallet_id.or_else(|| std::env::var("NYKS_WALLET_ID").ok())
 }
 
-/// Resolve an `OrderWallet` – load from DB using wallet_id (arg or env), or create fresh.
+/// Resolve an `OrderWallet` – load from DB using wallet_id (arg or env).
 ///
-/// Priority: CLI arg → `NYKS_WALLET_ID` env var → create a new ephemeral wallet.
-/// Password priority: CLI arg → `NYKS_WALLET_PASSPHRASE` env var.
+/// Priority: CLI arg → `NYKS_WALLET_ID` env var → error.
+/// Password priority: CLI arg → `NYKS_WALLET_PASSPHRASE` env var → session cache.
 #[cfg(any(feature = "sqlite", feature = "postgresql"))]
 async fn resolve_order_wallet(
     wallet_id: Option<String>,
     password: Option<String>,
 ) -> Result<OrderWallet, String> {
-    let wid = resolve_wallet_id(wallet_id);
+    let wid = resolve_wallet_id(wallet_id).ok_or(
+        "wallet_id is required (pass --wallet-id or set NYKS_WALLET_ID env var)"
+    )?;
     let pwd = resolve_password(password);
-    if let Some(wid) = wid {
-        load_order_wallet_from_db(&wid, pwd, None)
-    } else {
-        OrderWallet::new(None).map_err(|e| e.to_string())
-    }
+    load_order_wallet_from_db(&wid, pwd, None)
 }
 
 // ---------------------------------------------------------------------------
@@ -850,13 +860,18 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
         WalletCmd::Accounts {
             wallet_id,
             password,
+            on_chain_only,
         } => {
             #[cfg(any(feature = "sqlite", feature = "postgresql"))]
             let ow = resolve_order_wallet(wallet_id, password).await?;
             #[cfg(not(any(feature = "sqlite", feature = "postgresql")))]
             let ow = OrderWallet::new(None).map_err(|e| e.to_string())?;
 
-            let accounts = ow.zk_accounts.get_all_accounts();
+            let mut accounts = ow.zk_accounts.get_all_accounts();
+            accounts.sort_by_key(|a| a.index);
+            if on_chain_only {
+                accounts.retain(|a| a.on_chain);
+            }
             if accounts.is_empty() {
                 println!("No ZkOS accounts found");
             } else {

--- a/src/bin/relayer_cli.rs
+++ b/src/bin/relayer_cli.rs
@@ -546,18 +546,21 @@ fn load_order_wallet_from_db(
 
 #[cfg(unix)]
 fn get_ppid() -> Option<u32> {
-    let status = std::fs::read_to_string("/proc/self/status").ok()?;
-    for line in status.lines() {
-        if let Some(rest) = line.strip_prefix("PPid:") {
-            return rest.trim().parse().ok();
-        }
+    // Use libc::getppid() which works on both Linux and macOS.
+    // The previous /proc/self/status approach only worked on Linux.
+    let ppid = unsafe { libc::getppid() };
+    if ppid > 0 {
+        Some(ppid as u32)
+    } else {
+        None
     }
-    None
 }
 
 #[cfg(unix)]
 fn is_process_alive(pid: u32) -> bool {
-    std::path::Path::new(&format!("/proc/{pid}")).exists()
+    // Signal 0 checks process existence without sending a real signal.
+    // Works on both Linux and macOS (unlike /proc/{pid} which is Linux-only).
+    unsafe { libc::kill(pid as i32, 0) == 0 }
 }
 
 fn session_dir() -> Option<std::path::PathBuf> {
@@ -716,7 +719,7 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
 
             #[cfg(any(feature = "sqlite", feature = "postgresql"))]
             if with_db {
-                let pwd = password.map(|p| SecretString::new(p.into()));
+                let pwd = resolve_password(password).map(|p| SecretString::new(p.into()));
                 ow.with_db(pwd, wallet_id.clone())?;
                 println!(
                     "  Database persistence enabled (wallet_id: {})",
@@ -741,7 +744,7 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
 
             #[cfg(any(feature = "sqlite", feature = "postgresql"))]
             if with_db {
-                let pwd = password.map(|p| SecretString::new(p.into()));
+                let pwd = resolve_password(password).map(|p| SecretString::new(p.into()));
                 ow.with_db(pwd, wallet_id.clone())?;
                 println!(
                     "  Database persistence enabled (wallet_id: {})",

--- a/src/bin/relayer_cli.rs
+++ b/src/bin/relayer_cli.rs
@@ -1473,6 +1473,7 @@ async fn handle_portfolio(cmd: PortfolioCmd) -> Result<(), String> {
             println!("  Margin used:         {:.2}", portfolio.total_margin_used);
             println!("  Unrealized PnL:      {:.2}", portfolio.unrealized_pnl);
             println!("  Realised PnL:        {:.2}", portfolio.realised_pnl);
+            println!("  Liquidation Loss:    {:.2}", portfolio.liquidation_loss);
             println!(
                 "  Margin utilization:  {:.2}%",
                 portfolio.margin_utilization * 100.0
@@ -1578,6 +1579,32 @@ async fn handle_portfolio(cmd: PortfolioCmd) -> Result<(), String> {
                 println!(
                     "\n  Total Realised PnL: {:.2}",
                     portfolio.realised_pnl
+                );
+            }
+
+            if !portfolio.liquidated_trader_positions.is_empty() {
+                println!("\nLiquidated Positions");
+                println!("{}", "-".repeat(80));
+                println!(
+                    "  {:<6} {:<6} {:>12} {:>16} {:>6} {:>12} {:>10} {:>10}",
+                    "ACCT", "SIDE", "ENTRY", "SIZE", "LEV", "I.MARGIN", "FEE_FILL", "FEE_SETT"
+                );
+                for p in &portfolio.liquidated_trader_positions {
+                    println!(
+                        "  {:<6} {:<6} {:>12.2} {:>16.2} {:>5.0}x {:>12.2} {:>10.4} {:>10.4}",
+                        p.account_index,
+                        format!("{:?}", p.position_type),
+                        p.entry_price,
+                        p.position_size,
+                        p.leverage,
+                        p.initial_margin,
+                        p.fee_filled,
+                        p.fee_settled,
+                    );
+                }
+                println!(
+                    "\n  Total Liquidation Loss: {:.2}",
+                    portfolio.liquidation_loss
                 );
             }
 

--- a/src/bin/relayer_cli.rs
+++ b/src/bin/relayer_cli.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 use log::error;
 use nyks_wallet::relayer_module::order_wallet::OrderWallet;
+use nyks_wallet::relayer_module::relayer_types::OrderStatus;
 use secrecy::SecretString;
 
 // ---------------------------------------------------------------------------
@@ -1413,8 +1414,14 @@ async fn handle_portfolio(cmd: PortfolioCmd) -> Result<(), String> {
 
             let portfolio = ow.get_portfolio_summary().await?;
 
+            // Extract mark price from the first trader position (same for all).
+            let mark_price = portfolio.trader_positions.first().map(|p| p.current_price);
+
             println!("Portfolio Summary");
             println!("{}", "=".repeat(50));
+            if let Some(mp) = mark_price {
+                println!("  Mark price:          ${:.2}", mp);
+            }
             println!(
                 "  On-chain balance:    {} sats",
                 portfolio.wallet_balance_sats
@@ -1442,35 +1449,59 @@ async fn handle_portfolio(cmd: PortfolioCmd) -> Result<(), String> {
 
             if !portfolio.trader_positions.is_empty() {
                 println!("\nTrader Positions");
-                println!("{}", "-".repeat(115));
+                println!("{}", "-".repeat(160));
                 println!(
-                    "  {:<6} {:<6} {:>12} {:>12} {:>16} {:>6} {:>12} {:>14} {:>10}",
-                    "ACCT",
-                    "SIDE",
-                    "ENTRY",
-                    "CURRENT",
-                    "SIZE",
-                    "LEV",
-                    "PnL",
-                    "LIQ PRICE",
-                    "FUNDING"
+                    "  {:<6} {:<10} {:<6} {:>12} {:>16} {:>6} {:>10} {:>12} {:>14} {:>10} {:>12} {:>10} {:>10} {:>10}",
+                    "ACCT", "STATUS", "SIDE", "ENTRY", "SIZE", "LEV", "A.MARGIN",
+                    "U_PnL", "LIQ PRICE", "FEE", "FUNDING", "LIMIT", "TP", "SL"
                 );
                 for p in &portfolio.trader_positions {
                     let funding_str = p
                         .funding_applied
                         .map(|v| format!("{:.4}", v))
                         .unwrap_or_else(|| "-".to_string());
+                    let limit_str = p
+                        .settle_limit
+                        .as_ref()
+                        .map(|t| format!("{:.2}", t.price))
+                        .unwrap_or_else(|| "-".to_string());
+                    let tp_str = p
+                        .take_profit
+                        .as_ref()
+                        .map(|t| format!("{:.2}", t.price))
+                        .unwrap_or_else(|| "-".to_string());
+                    let sl_str = p
+                        .stop_loss
+                        .as_ref()
+                        .map(|t| format!("{:.2}", t.price))
+                        .unwrap_or_else(|| "-".to_string());
+                    let is_pending = p.order_status == OrderStatus::PENDING;
+                    let pnl_str = if is_pending {
+                        "-".to_string()
+                    } else {
+                        format!("{:.2}", p.unrealized_pnl)
+                    };
+                    let liq_str = if is_pending {
+                        "-".to_string()
+                    } else {
+                        format!("{:.2}", p.liquidation_price)
+                    };
                     println!(
-                        "  {:<6} {:<6} {:>12.2} {:>12.2} {:>16.2} {:>5.0}x {:>12.2} {:>14.2} {:>10}",
+                        "  {:<6} {:<10} {:<6} {:>12.2} {:>16.2} {:>5.0}x {:>10.2} {:>12} {:>14} {:>10.4} {:>12} {:>10} {:>10} {:>10}",
                         p.account_index,
+                        format!("{:?}", p.order_status),
                         format!("{:?}", p.position_type),
                         p.entry_price,
-                        p.current_price,
                         p.position_size,
                         p.leverage,
-                        p.unrealized_pnl,
-                        p.liquidation_price,
+                        p.available_margin,
+                        pnl_str,
+                        liq_str,
+                        p.fee_filled,
                         funding_str,
+                        limit_str,
+                        tp_str,
+                        sl_str,
                     );
                 }
             }

--- a/src/bin/relayer_cli.rs
+++ b/src/bin/relayer_cli.rs
@@ -21,6 +21,10 @@ enum Commands {
     #[command(subcommand)]
     Wallet(WalletCmd),
 
+    /// ZkOS account management (fund, withdraw, transfer, split)
+    #[command(subcommand)]
+    Zkaccount(ZkaccountCmd),
+
     /// Order and trading commands
     #[command(subcommand)]
     Order(OrderCmd),
@@ -196,11 +200,11 @@ enum WalletCmd {
 }
 
 // ---------------------------------------------------------------------------
-// Order sub-commands
+// ZkOS account sub-commands
 // ---------------------------------------------------------------------------
 
 #[derive(Subcommand)]
-enum OrderCmd {
+enum ZkaccountCmd {
     /// Fund a new ZkOS trading account from the on-chain wallet
     Fund {
         /// Amount in satoshis to fund
@@ -264,7 +268,14 @@ enum OrderCmd {
         #[arg(long)]
         password: Option<String>,
     },
+}
 
+// ---------------------------------------------------------------------------
+// Order sub-commands
+// ---------------------------------------------------------------------------
+
+#[derive(Subcommand)]
+enum OrderCmd {
     /// Open a trader order (leveraged derivative)
     OpenTrade {
         /// ZkOS account index to use
@@ -518,6 +529,21 @@ enum MarketCmd {
 
     /// Get lend pool info
     LendPool,
+
+    /// Get current pool share value
+    PoolShareValue,
+
+    /// Get last 24-hour annualized percentage yield (APY)
+    LastDayApy,
+
+    /// Get open interest (long/short exposure)
+    OpenInterest,
+
+    /// Get comprehensive market risk statistics
+    MarketStats,
+
+    /// Get relayer server time
+    ServerTime,
 }
 
 // ---------------------------------------------------------------------------
@@ -529,7 +555,9 @@ fn parse_order_type(s: &str) -> Result<twilight_client_sdk::relayer_types::Order
         "MARKET" => Ok(twilight_client_sdk::relayer_types::OrderType::MARKET),
         "LIMIT" => Ok(twilight_client_sdk::relayer_types::OrderType::LIMIT),
         "SLTP" => Ok(twilight_client_sdk::relayer_types::OrderType::SLTP),
-        other => Err(format!("Unknown order type: {other}. Use MARKET, LIMIT, or SLTP")),
+        other => Err(format!(
+            "Unknown order type: {other}. Use MARKET, LIMIT, or SLTP"
+        )),
     }
 }
 
@@ -588,7 +616,11 @@ fn is_process_alive(pid: u32) -> bool {
 
 fn session_dir() -> Option<std::path::PathBuf> {
     let home = std::env::var("HOME").ok()?;
-    Some(std::path::PathBuf::from(home).join(".cache").join("nyks-wallet"))
+    Some(
+        std::path::PathBuf::from(home)
+            .join(".cache")
+            .join("nyks-wallet"),
+    )
 }
 
 #[cfg(unix)]
@@ -620,7 +652,8 @@ fn session_save(password: &str) -> Result<(), String> {
         .mode(0o600)
         .open(&path)
         .map_err(|e| e.to_string())?;
-    file.write_all(content.as_bytes()).map_err(|e| e.to_string())?;
+    file.write_all(content.as_bytes())
+        .map_err(|e| e.to_string())?;
 
     Ok(())
 }
@@ -668,7 +701,9 @@ fn session_save(_password: &str) -> Result<(), String> {
     Err("session cache is only supported on Unix".to_string())
 }
 #[cfg(not(unix))]
-fn session_load() -> Option<String> { None }
+fn session_load() -> Option<String> {
+    None
+}
 #[cfg(not(unix))]
 fn session_clear() {}
 
@@ -697,9 +732,8 @@ async fn resolve_order_wallet(
     wallet_id: Option<String>,
     password: Option<String>,
 ) -> Result<OrderWallet, String> {
-    let wid = resolve_wallet_id(wallet_id).ok_or(
-        "wallet_id is required (pass --wallet-id or set NYKS_WALLET_ID env var)"
-    )?;
+    let wid = resolve_wallet_id(wallet_id)
+        .ok_or("wallet_id is required (pass --wallet-id or set NYKS_WALLET_ID env var)")?;
     let pwd = resolve_password(password);
     load_order_wallet_from_db(&wid, pwd, None)
 }
@@ -717,6 +751,7 @@ async fn main() {
 
     let result = match cli.command {
         Commands::Wallet(cmd) => handle_wallet(cmd).await,
+        Commands::Zkaccount(cmd) => handle_zkaccount(cmd).await,
         Commands::Order(cmd) => handle_order(cmd).await,
         Commands::Market(cmd) => handle_market(cmd).await,
         Commands::History(cmd) => handle_history(cmd).await,
@@ -800,9 +835,10 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
         }
 
         #[cfg(not(any(feature = "sqlite", feature = "postgresql")))]
-        WalletCmd::Load { .. } => {
-            Err("Database features (sqlite/postgresql) not enabled. Rebuild with --features sqlite".to_string())
-        }
+        WalletCmd::Load { .. } => Err(
+            "Database features (sqlite/postgresql) not enabled. Rebuild with --features sqlite"
+                .to_string(),
+        ),
 
         WalletCmd::Balance {
             wallet_id,
@@ -813,7 +849,11 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
             #[cfg(not(any(feature = "sqlite", feature = "postgresql")))]
             let mut ow = OrderWallet::new(None).map_err(|e| e.to_string())?;
 
-            let balance = ow.wallet.update_balance().await.map_err(|e| e.to_string())?;
+            let balance = ow
+                .wallet
+                .update_balance()
+                .await
+                .map_err(|e| e.to_string())?;
             println!("Wallet Balance");
             println!("  Address:  {}", ow.wallet.twilightaddress);
             println!("  NYKS:     {}", balance.nyks);
@@ -838,9 +878,10 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
         }
 
         #[cfg(not(any(feature = "sqlite", feature = "postgresql")))]
-        WalletCmd::List { .. } => {
-            Err("Database features (sqlite/postgresql) not enabled. Rebuild with --features sqlite".to_string())
-        }
+        WalletCmd::List { .. } => Err(
+            "Database features (sqlite/postgresql) not enabled. Rebuild with --features sqlite"
+                .to_string(),
+        ),
 
         WalletCmd::Export {
             output,
@@ -852,7 +893,9 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
             #[cfg(not(any(feature = "sqlite", feature = "postgresql")))]
             let ow = OrderWallet::new(None).map_err(|e| e.to_string())?;
 
-            ow.wallet.export_to_json(&output).map_err(|e| e.to_string())?;
+            ow.wallet
+                .export_to_json(&output)
+                .map_err(|e| e.to_string())?;
             println!("Wallet exported to {output}");
             Ok(())
         }
@@ -901,7 +944,8 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
             password,
         } => {
             let ow = load_order_wallet_from_db(&wallet_id, password, None)?;
-            let db_manager = ow.get_db_manager()
+            let db_manager = ow
+                .get_db_manager()
                 .ok_or("Database not enabled on this wallet")?;
             db_manager.export_backup_to_file(&output)?;
             println!("Backup exported to {output}");
@@ -909,9 +953,10 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
         }
 
         #[cfg(not(any(feature = "sqlite", feature = "postgresql")))]
-        WalletCmd::Backup { .. } => {
-            Err("Database features (sqlite/postgresql) not enabled. Rebuild with --features sqlite".to_string())
-        }
+        WalletCmd::Backup { .. } => Err(
+            "Database features (sqlite/postgresql) not enabled. Rebuild with --features sqlite"
+                .to_string(),
+        ),
 
         #[cfg(any(feature = "sqlite", feature = "postgresql"))]
         WalletCmd::Restore {
@@ -921,7 +966,8 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
             force,
         } => {
             let ow = load_order_wallet_from_db(&wallet_id, password, None)?;
-            let db_manager = ow.get_db_manager()
+            let db_manager = ow
+                .get_db_manager()
                 .ok_or("Database not enabled on this wallet")?;
             db_manager.import_backup_from_file(&input, force)?;
             println!("Backup restored from {input}");
@@ -929,9 +975,10 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
         }
 
         #[cfg(not(any(feature = "sqlite", feature = "postgresql")))]
-        WalletCmd::Restore { .. } => {
-            Err("Database features (sqlite/postgresql) not enabled. Rebuild with --features sqlite".to_string())
-        }
+        WalletCmd::Restore { .. } => Err(
+            "Database features (sqlite/postgresql) not enabled. Rebuild with --features sqlite"
+                .to_string(),
+        ),
 
         WalletCmd::SyncNonce {
             wallet_id,
@@ -946,18 +993,23 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
             println!("Nonce synced from chain");
             println!("  Next sequence: {}", ow.nonce_manager.peek_next());
             println!("  Account number: {}", ow.nonce_manager.account_number());
-            println!("  Released (pending reuse): {}", ow.nonce_manager.released_count());
+            println!(
+                "  Released (pending reuse): {}",
+                ow.nonce_manager.released_count()
+            );
             Ok(())
         }
 
         WalletCmd::Unlock => {
             // If a session is already active, ask before overwriting.
             if session_load().is_some() {
-                eprintln!("A session password is already cached. Run `wallet lock` first to clear it.");
+                eprintln!(
+                    "A session password is already cached. Run `wallet lock` first to clear it."
+                );
                 return Err("session already active".to_string());
             }
-            let password = rpassword::prompt_password("Wallet password: ")
-                .map_err(|e| e.to_string())?;
+            let password =
+                rpassword::prompt_password("Wallet password: ").map_err(|e| e.to_string())?;
             if password.is_empty() {
                 return Err("password must not be empty".to_string());
             }
@@ -976,12 +1028,12 @@ async fn handle_wallet(cmd: WalletCmd) -> Result<(), String> {
 }
 
 // ---------------------------------------------------------------------------
-// Order handlers
+// ZkOS account handlers
 // ---------------------------------------------------------------------------
 
-async fn handle_order(cmd: OrderCmd) -> Result<(), String> {
+async fn handle_zkaccount(cmd: ZkaccountCmd) -> Result<(), String> {
     match cmd {
-        OrderCmd::Fund {
+        ZkaccountCmd::Fund {
             amount,
             wallet_id,
             password,
@@ -1000,7 +1052,7 @@ async fn handle_order(cmd: OrderCmd) -> Result<(), String> {
             Ok(())
         }
 
-        OrderCmd::Withdraw {
+        ZkaccountCmd::Withdraw {
             account_index,
             wallet_id,
             password,
@@ -1016,7 +1068,7 @@ async fn handle_order(cmd: OrderCmd) -> Result<(), String> {
             Ok(())
         }
 
-        OrderCmd::Transfer {
+        ZkaccountCmd::Transfer {
             from,
             wallet_id,
             password,
@@ -1033,7 +1085,7 @@ async fn handle_order(cmd: OrderCmd) -> Result<(), String> {
             Ok(())
         }
 
-        OrderCmd::Split {
+        ZkaccountCmd::Split {
             from,
             balances,
             wallet_id,
@@ -1073,7 +1125,15 @@ async fn handle_order(cmd: OrderCmd) -> Result<(), String> {
             }
             Ok(())
         }
+    }
+}
 
+// ---------------------------------------------------------------------------
+// Order handlers
+// ---------------------------------------------------------------------------
+
+async fn handle_order(cmd: OrderCmd) -> Result<(), String> {
+    match cmd {
         OrderCmd::OpenTrade {
             account_index,
             order_type,
@@ -1238,7 +1298,10 @@ async fn handle_history(cmd: HistoryCmd) -> Result<(), String> {
     #[cfg(not(any(feature = "sqlite", feature = "postgresql")))]
     {
         let _ = cmd;
-        return Err("Database features (sqlite/postgresql) not enabled. Rebuild with --features sqlite".to_string());
+        return Err(
+            "Database features (sqlite/postgresql) not enabled. Rebuild with --features sqlite"
+                .to_string(),
+        );
     }
 
     #[cfg(any(feature = "sqlite", feature = "postgresql"))]
@@ -1352,13 +1415,25 @@ async fn handle_portfolio(cmd: PortfolioCmd) -> Result<(), String> {
 
             println!("Portfolio Summary");
             println!("{}", "=".repeat(50));
-            println!("  On-chain balance:    {} sats", portfolio.wallet_balance_sats);
-            println!("  Trading balance:     {} sats", portfolio.total_trading_balance);
+            println!(
+                "  On-chain balance:    {} sats",
+                portfolio.wallet_balance_sats
+            );
+            println!(
+                "  Trading balance:     {} sats",
+                portfolio.total_trading_balance
+            );
             println!("  Margin used:         {:.2}", portfolio.total_margin_used);
             println!("  Unrealized PnL:      {:.2}", portfolio.unrealized_pnl);
-            println!("  Margin utilization:  {:.2}%", portfolio.margin_utilization * 100.0);
+            println!(
+                "  Margin utilization:  {:.2}%",
+                portfolio.margin_utilization * 100.0
+            );
             println!();
-            println!("  Lend deposits:       {:.2}", portfolio.total_lend_deposits);
+            println!(
+                "  Lend deposits:       {:.2}",
+                portfolio.total_lend_deposits
+            );
             println!("  Lend value:          {:.2}", portfolio.total_lend_value);
             println!("  Lend PnL:            {:.2}", portfolio.lend_pnl);
             println!();
@@ -1370,7 +1445,15 @@ async fn handle_portfolio(cmd: PortfolioCmd) -> Result<(), String> {
                 println!("{}", "-".repeat(115));
                 println!(
                     "  {:<6} {:<6} {:>12} {:>12} {:>16} {:>6} {:>12} {:>14} {:>10}",
-                    "ACCT", "SIDE", "ENTRY", "CURRENT", "SIZE", "LEV", "PnL", "LIQ PRICE", "FUNDING"
+                    "ACCT",
+                    "SIDE",
+                    "ENTRY",
+                    "CURRENT",
+                    "SIZE",
+                    "LEV",
+                    "PnL",
+                    "LIQ PRICE",
+                    "FUNDING"
                 );
                 for p in &portfolio.trader_positions {
                     let funding_str = p
@@ -1520,7 +1603,10 @@ async fn handle_market(cmd: MarketCmd) -> Result<(), String> {
         }
 
         MarketCmd::Orderbook => {
-            let book = client.open_limit_orders().await.map_err(|e| e.to_string())?;
+            let book = client
+                .open_limit_orders()
+                .await
+                .map_err(|e| e.to_string())?;
             println!("Order Book");
             println!("\n  BIDS (buy):");
             println!("  {:<16} {:<16}", "PRICE", "SIZE");
@@ -1589,6 +1675,79 @@ async fn handle_market(cmd: MarketCmd) -> Result<(), String> {
                 "{}",
                 serde_json::to_string_pretty(&info).unwrap_or_else(|_| format!("{:?}", info))
             );
+        }
+
+        MarketCmd::PoolShareValue => {
+            let value = client.pool_share_value().await.map_err(|e| e.to_string())?;
+            println!("Pool Share Value");
+            println!("  Value: {:.8}", value);
+        }
+
+        MarketCmd::LastDayApy => {
+            let apy = client.last_day_apy().await.map_err(|e| e.to_string())?;
+            println!("Last 24h APY");
+            match apy {
+                Some(v) => println!("  APY: {:.4}%", v),
+                None => println!("  APY: not available"),
+            }
+        }
+
+        MarketCmd::OpenInterest => {
+            let oi = client.open_interest().await.map_err(|e| e.to_string())?;
+            println!("Open Interest");
+            println!("  Long exposure:  {:.4} SATS", oi.long_exposure);
+            println!("  Short exposure: {:.4} SATS", oi.short_exposure);
+            if let Some(ts) = &oi.last_order_timestamp {
+                println!("  Last order:     {}", ts);
+            }
+        }
+
+        MarketCmd::MarketStats => {
+            let stats = client.get_market_stats().await.map_err(|e| e.to_string())?;
+            println!("Market Statistics");
+            println!("{}", "=".repeat(45));
+            println!("  Pool equity:       {:.4} SATS", stats.pool_equity_btc);
+            println!("  Total long:        {:.4} SATS", stats.total_long_btc);
+            println!("  Total short:       {:.4} SATS", stats.total_short_btc);
+            println!(
+                "  Pending long:      {:.4} SATS",
+                stats.total_pending_long_btc
+            );
+            println!(
+                "  Pending short:     {:.4} SATS",
+                stats.total_pending_short_btc
+            );
+            println!("  Open interest:     {:.4} SATS", stats.open_interest_btc);
+            println!("  Net exposure:      {:.4} SATS", stats.net_exposure_btc);
+            println!("  Long %:            {:.2}%", stats.long_pct * 100.0);
+            println!("  Short %:           {:.2}%", stats.short_pct * 100.0);
+            println!("  Utilization:       {:.2}%", stats.utilization * 100.0);
+            println!("  Max long:          {:.4} SATS", stats.max_long_btc);
+            println!("  Max short:         {:.4} SATS", stats.max_short_btc);
+            println!("  Status:            {}", stats.status);
+            if let Some(reason) = &stats.status_reason {
+                println!("  Status reason:     {}", reason);
+            }
+            println!("\nRisk Parameters");
+            println!("{}", "-".repeat(45));
+            println!("  Max OI multiplier: {:.2}", stats.params.max_oi_mult);
+            println!("  Max net multiplier:{:.2}", stats.params.max_net_mult);
+            println!(
+                "  Max position %:    {:.2}%",
+                stats.params.max_position_pct * 100.0
+            );
+            println!(
+                "  Min position:      {:.4} BTC",
+                stats.params.min_position_btc
+            );
+            println!("  Max leverage:      {:.0}x", stats.params.max_leverage);
+            println!("  MM ratio:          {:.4}", stats.params.mm_ratio);
+        }
+
+        MarketCmd::ServerTime => {
+            let time = client.server_time().await.map_err(|e| e.to_string())?;
+            println!("Server Time");
+            println!("  UTC: {}", time);
         }
     }
     Ok(())

--- a/src/relayer_module/order_wallet.rs
+++ b/src/relayer_module/order_wallet.rs
@@ -14,8 +14,8 @@ use crate::{
     config::{EndpointConfig, RelayerEndPointConfig},
     error::{Result as WalletResult, WalletError},
     relayer_module::{
-        self, fetch_removed_utxo_details_with_retry, fetch_tx_hash_with_retry,
-        fetch_utxo_details_with_retry,
+        self, fetch_removed_utxo_details_with_retry, fetch_tx_hash_with_account_address_retry,
+        fetch_tx_hash_with_retry, fetch_utxo_details_with_retry,
         nonce_manager::NonceManager,
         relayer_api::RelayerJsonRpcClient,
         relayer_order::{
@@ -1223,6 +1223,71 @@ impl OrderWallet {
         }
 
         Ok(request_id)
+    }
+
+    /// Check if a previously closed (e.g. SLTP) trader order has settled and, if so,
+    /// unlock the account by refreshing its UTXO, balance, and IO type back to `Coin`.
+    ///
+    /// Returns the current `OrderStatus` so the caller can decide what to do next.
+    pub async fn unlock_settled_order(
+        &mut self,
+        index: AccountIndex,
+    ) -> Result<OrderStatus, String> {
+        let trader_order = self.query_trader_order(index).await?;
+
+        if trader_order.order_status != OrderStatus::SETTLED {
+            return Ok(trader_order.order_status);
+        }
+
+        let account_address = self.zk_accounts.get_account_address(&index)?.to_string();
+        let tx_hash = fetch_tx_hash_with_account_address_retry(
+            &account_address,
+            Some(OrderStatus::SETTLED),
+            &self.relayer_api_client,
+        )
+        .await?;
+        let request_id = tx_hash.request_id.unwrap_or_default();
+        let utxo_detail = fetch_utxo_details_with_retry(account_address, IOType::Coin).await?;
+        self.utxo_details.insert(index, utxo_detail.clone());
+
+        // Sync to database
+        #[cfg(any(feature = "sqlite", feature = "postgresql"))]
+        if let Err(e) = self.sync_utxo_detail_to_db(index, &utxo_detail) {
+            error!("Failed to sync UTXO detail to database: {}", e);
+        }
+
+        // let trader_order = self.query_trader_order(index).await?;
+        self.zk_accounts
+            .update_balance(&index, trader_order.available_margin as u64)?;
+        debug!(
+            "trader_order available_margin: {:?}",
+            trader_order.available_margin as u64
+        );
+        self.zk_accounts.update_io_type(&index, IOType::Coin)?;
+        let account = utxo_detail.output.to_quisquis_account()?;
+        self.zk_accounts.update_qq_account(&index, account)?;
+
+        #[cfg(any(feature = "sqlite", feature = "postgresql"))]
+        {
+            if let Ok(account) = self.zk_accounts.get_account(&index) {
+                let _ = self.update_zk_account_in_db(&account);
+            }
+            self.log_order_history(
+                index,
+                &request_id.to_string(),
+                "close",
+                "MARKET",
+                Some(&format!("{:?}", trader_order.position_type)),
+                trader_order.available_margin as u64,
+                Some(0.0),
+                Some(trader_order.leverage as u64),
+                Some(trader_order.unrealized_pnl),
+                "settled",
+                None,
+            );
+        }
+
+        Ok(trader_order.order_status)
     }
 
     // -------------------------

--- a/src/relayer_module/order_wallet.rs
+++ b/src/relayer_module/order_wallet.rs
@@ -938,7 +938,7 @@ impl OrderWallet {
             &secret_key,
             account_address.clone(),
             tx_hash.order_id,
-            order_type,
+            order_type.clone(),
             execution_price,
             &self.relayer_api_client,
         )
@@ -952,6 +952,10 @@ impl OrderWallet {
             );
             return Ok(request_id);
         }
+        if order_type == OrderType::LIMIT {
+            info!("Limit order is settled on Market Price due to mark price hit limit price");
+        }
+
         let utxo_detail = fetch_utxo_details_with_retry(account_address, IOType::Coin).await?;
         self.utxo_details.insert(index, utxo_detail.clone());
 
@@ -962,6 +966,11 @@ impl OrderWallet {
         }
 
         let trader_order = self.query_trader_order(index).await?;
+        info!(
+            "PnL: {:?}, Net PnL: {:?}",
+            trader_order.unrealized_pnl,
+            trader_order.available_margin - trader_order.initial_margin
+        );
         self.zk_accounts
             .update_balance(&index, trader_order.available_margin as u64)?;
         debug!(
@@ -1030,7 +1039,6 @@ impl OrderWallet {
         let tx_hash = fetch_tx_hash_with_retry(&request_id, &self.relayer_api_client).await?;
         tokio::time::sleep(Duration::from_millis(200)).await;
         let trader_order = self.query_trader_order(index).await?;
-        info!("trader_order: {:?}", trader_order);
         if trader_order.order_status != OrderStatus::SETTLED {
             // SLTP orders are conditional — they stay pending until the market
             // price hits the stop-loss or take-profit level.  We only need to
@@ -1058,9 +1066,11 @@ impl OrderWallet {
                 );
             }
         } else {
+            info!("Order settled on Market Price due to mark price hit SLTP price");
             info!(
-                "Order settled on Market Price due to SLTP price hit, status: {}",
-                tx_hash.order_status.to_str()
+                "PnL: {:?}, Net PnL: {:?}",
+                trader_order.unrealized_pnl,
+                trader_order.available_margin - trader_order.initial_margin
             );
             let utxo_detail = fetch_utxo_details_with_retry(account_address, IOType::Coin).await?;
             self.utxo_details.insert(index, utxo_detail.clone());
@@ -1812,6 +1822,7 @@ impl OrderWallet {
 
         let mut total_trading_balance: u64 = 0;
         let mut trader_positions = Vec::new();
+        let mut closed_trader_positions = Vec::new();
         let mut lend_positions = Vec::new();
         let mut on_chain_count = 0;
 
@@ -1838,13 +1849,43 @@ impl OrderWallet {
                     // Try trader order first, fall back to lend order
                     match self.query_trader_order_v1(account.index).await {
                         Ok(order_v1) => {
-                            trader_positions.push(
-                                super::portfolio::PositionSummary::from_trader_order_v1(
-                                    account.index,
-                                    &order_v1,
-                                    current_price,
-                                ),
-                            );
+                            if order_v1.order.order_status == OrderStatus::SETTLED {
+                                // Build summary using the relayer's PnL (realised)
+                                let mut summary =
+                                    super::portfolio::PositionSummary::from_trader_order_v1(
+                                        account.index,
+                                        &order_v1,
+                                        current_price,
+                                    );
+                                // Use the relayer-reported unrealized_pnl as realised PnL
+                                summary.unrealized_pnl = order_v1.order.unrealized_pnl;
+
+                                // Unlock the settled account (refresh UTXO, restore to Coin)
+                                match self.unlock_settled_order(account.index).await {
+                                    Ok(_) => {
+                                        info!(
+                                            "Unlocked settled account {} during portfolio scan",
+                                            account.index
+                                        );
+                                    }
+                                    Err(e) => {
+                                        error!(
+                                            "Failed to unlock settled account {}: {}",
+                                            account.index, e
+                                        );
+                                    }
+                                }
+
+                                closed_trader_positions.push(summary);
+                            } else {
+                                trader_positions.push(
+                                    super::portfolio::PositionSummary::from_trader_order_v1(
+                                        account.index,
+                                        &order_v1,
+                                        current_price,
+                                    ),
+                                );
+                            }
                         }
                         Err(_) => {
                             // Not a trader order — try lend
@@ -1874,6 +1915,7 @@ impl OrderWallet {
             wallet_balance_sats,
             total_trading_balance,
             trader_positions,
+            closed_trader_positions,
             lend_positions,
             total_accounts,
             on_chain_count,

--- a/src/relayer_module/order_wallet.rs
+++ b/src/relayer_module/order_wallet.rs
@@ -6,7 +6,7 @@
 //! - Open/close/cancel trader and lend orders via the relayer
 //! - Query order states with retry helpers
 //! - Optionally persist wallet, ZK accounts, UTXOs, and request IDs in a database
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 use std::sync::Arc;
 
@@ -34,7 +34,7 @@ use crate::{
 use crate::database::{connection::run_migrations_once, DatabaseManager, WalletList};
 #[cfg(any(feature = "sqlite", feature = "postgresql"))]
 use crate::security::SecurePassword;
-use log::{debug, error};
+use log::{debug, error, info};
 use relayer_module::utils::{build_and_sign_msg_mint_burn_trading_btc, send_tx_to_chain, TxResult};
 #[cfg(any(feature = "sqlite", feature = "postgresql"))]
 use secrecy::{ExposeSecret, SecretString};
@@ -945,10 +945,12 @@ impl OrderWallet {
         .await?;
         let tx_hash = fetch_tx_hash_with_retry(&request_id, &self.relayer_api_client).await?;
         if tx_hash.order_status != OrderStatus::SETTLED {
-            return Err(format!(
-                "Order is not settled, status: {}",
+            // order_type is LIMIT , so we need to wait for the order to be settled
+            info!(
+                "Limit order is not settled, status: {}",
                 tx_hash.order_status.to_str()
-            ));
+            );
+            return Ok(request_id);
         }
         let utxo_detail = fetch_utxo_details_with_retry(account_address, IOType::Coin).await?;
         self.utxo_details.insert(index, utxo_detail.clone());
@@ -990,6 +992,7 @@ impl OrderWallet {
         }
         Ok(request_id)
     }
+
     pub async fn close_trader_order_sltp(
         &mut self,
         index: AccountIndex,
@@ -1025,49 +1028,78 @@ impl OrderWallet {
         )
         .await?;
         let tx_hash = fetch_tx_hash_with_retry(&request_id, &self.relayer_api_client).await?;
-        if tx_hash.order_status != OrderStatus::SETTLED {
-            return Err(format!(
-                "Order is not settled, status: {}",
-                tx_hash.order_status.to_str()
-            ));
-        }
-        let utxo_detail = fetch_utxo_details_with_retry(account_address, IOType::Coin).await?;
-        self.utxo_details.insert(index, utxo_detail.clone());
-
-        // Sync to database
-        #[cfg(any(feature = "sqlite", feature = "postgresql"))]
-        if let Err(e) = self.sync_utxo_detail_to_db(index, &utxo_detail) {
-            error!("Failed to sync UTXO detail to database: {}", e);
-        }
-
+        tokio::time::sleep(Duration::from_millis(200)).await;
         let trader_order = self.query_trader_order(index).await?;
-        self.zk_accounts
-            .update_balance(&index, trader_order.available_margin as u64)?;
-        debug!(
-            "trader_order available_margin: {:?}",
-            trader_order.available_margin as u64
-        );
-        self.zk_accounts.update_io_type(&index, IOType::Coin)?;
-        let account = utxo_detail.output.to_quisquis_account()?;
-        self.zk_accounts.update_qq_account(&index, account)?;
-        #[cfg(any(feature = "sqlite", feature = "postgresql"))]
-        {
-            if let Ok(account) = self.zk_accounts.get_account(&index) {
-                let _ = self.update_zk_account_in_db(&account);
-            }
-            self.log_order_history(
-                index,
-                &request_id,
-                "close_sltp",
-                &order_type_str,
-                Some(&format!("{:?}", trader_order.position_type)),
-                trader_order.available_margin as u64,
-                Some(execution_price),
-                Some(trader_order.leverage as u64),
-                Some(trader_order.unrealized_pnl),
-                "settled",
-                None,
+        info!("trader_order: {:?}", trader_order);
+        if trader_order.order_status != OrderStatus::SETTLED {
+            // SLTP orders are conditional — they stay pending until the market
+            // price hits the stop-loss or take-profit level.  We only need to
+            // confirm the order was accepted (tx hash exists), not that it has
+            // already settled.
+            info!(
+                "SLTP close order submitted, status: {}",
+                tx_hash.order_status.to_str()
             );
+            #[cfg(any(feature = "sqlite", feature = "postgresql"))]
+            {
+                // let trader_order = self.query_trader_order(index).await.ok();
+                self.log_order_history(
+                    index,
+                    &request_id,
+                    "close_sltp",
+                    &order_type_str,
+                    Some(&format!("{:?}", trader_order.position_type)),
+                    trader_order.available_margin as u64,
+                    Some(execution_price),
+                    Some(trader_order.leverage as u64),
+                    Some(trader_order.unrealized_pnl),
+                    &tx_hash.order_status.to_str(),
+                    None,
+                );
+            }
+        } else {
+            info!(
+                "Order settled on Market Price due to SLTP price hit, status: {}",
+                tx_hash.order_status.to_str()
+            );
+            let utxo_detail = fetch_utxo_details_with_retry(account_address, IOType::Coin).await?;
+            self.utxo_details.insert(index, utxo_detail.clone());
+
+            // Sync to database
+            #[cfg(any(feature = "sqlite", feature = "postgresql"))]
+            if let Err(e) = self.sync_utxo_detail_to_db(index, &utxo_detail) {
+                error!("Failed to sync UTXO detail to database: {}", e);
+            }
+
+            let trader_order = self.query_trader_order(index).await?;
+            self.zk_accounts
+                .update_balance(&index, trader_order.available_margin as u64)?;
+            debug!(
+                "trader_order available_margin: {:?}",
+                trader_order.available_margin as u64
+            );
+            self.zk_accounts.update_io_type(&index, IOType::Coin)?;
+            let account = utxo_detail.output.to_quisquis_account()?;
+            self.zk_accounts.update_qq_account(&index, account)?;
+            #[cfg(any(feature = "sqlite", feature = "postgresql"))]
+            {
+                if let Ok(account) = self.zk_accounts.get_account(&index) {
+                    let _ = self.update_zk_account_in_db(&account);
+                }
+                self.log_order_history(
+                    index,
+                    &request_id,
+                    "close_sltp",
+                    &order_type_str,
+                    Some(&format!("{:?}", trader_order.position_type)),
+                    trader_order.available_margin as u64,
+                    Some(execution_price),
+                    Some(trader_order.leverage as u64),
+                    Some(trader_order.unrealized_pnl),
+                    "settled",
+                    Some(&tx_hash.tx_hash),
+                );
+            }
         }
         Ok(request_id)
     }
@@ -1598,10 +1630,7 @@ impl OrderWallet {
         &self,
         filter: super::transaction_history::OrderHistoryFilter,
     ) -> Result<Vec<super::transaction_history::OrderHistoryEntry>, String> {
-        let db_manager = self
-            .db_manager
-            .as_ref()
-            .ok_or("Database not enabled")?;
+        let db_manager = self.db_manager.as_ref().ok_or("Database not enabled")?;
 
         let limit = filter.limit.unwrap_or(100);
         let offset = filter.offset.unwrap_or(0);
@@ -1625,10 +1654,7 @@ impl OrderWallet {
         &self,
         filter: super::transaction_history::TransferHistoryFilter,
     ) -> Result<Vec<super::transaction_history::TransferHistoryEntry>, String> {
-        let db_manager = self
-            .db_manager
-            .as_ref()
-            .ok_or("Database not enabled")?;
+        let db_manager = self.db_manager.as_ref().ok_or("Database not enabled")?;
 
         let limit = filter.limit.unwrap_or(100);
         let offset = filter.offset.unwrap_or(0);
@@ -1711,9 +1737,7 @@ impl OrderWallet {
     /// Accounts in Coin state contribute to `total_trading_balance`.
     /// Accounts in Memo state are queried as trader positions first; if that fails,
     /// they are tried as lend positions.
-    pub async fn get_portfolio_summary(
-        &mut self,
-    ) -> Result<super::portfolio::Portfolio, String> {
+    pub async fn get_portfolio_summary(&mut self) -> Result<super::portfolio::Portfolio, String> {
         let current_price = self
             .relayer_api_client
             .btc_usd_price()
@@ -1726,7 +1750,12 @@ impl OrderWallet {
         let mut lend_positions = Vec::new();
         let mut on_chain_count = 0;
 
-        let accounts: Vec<_> = self.zk_accounts.get_all_accounts().into_iter().cloned().collect();
+        let accounts: Vec<_> = self
+            .zk_accounts
+            .get_all_accounts()
+            .into_iter()
+            .cloned()
+            .collect();
         let total_accounts = accounts.len();
 
         for account in &accounts {
@@ -1802,7 +1831,12 @@ impl OrderWallet {
             return Err("Could not fetch current BTC/USD price".to_string());
         }
 
-        let accounts: Vec<_> = self.zk_accounts.get_all_accounts().into_iter().cloned().collect();
+        let accounts: Vec<_> = self
+            .zk_accounts
+            .get_all_accounts()
+            .into_iter()
+            .cloned()
+            .collect();
         let mut risks = Vec::new();
 
         for account in &accounts {
@@ -1840,7 +1874,11 @@ impl OrderWallet {
         }
 
         // Sort by distance — most at-risk (lowest distance) first
-        risks.sort_by(|a, b| a.distance_pct.partial_cmp(&b.distance_pct).unwrap_or(std::cmp::Ordering::Equal));
+        risks.sort_by(|a, b| {
+            a.distance_pct
+                .partial_cmp(&b.distance_pct)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         Ok(risks)
     }

--- a/src/relayer_module/order_wallet.rs
+++ b/src/relayer_module/order_wallet.rs
@@ -1823,6 +1823,7 @@ impl OrderWallet {
         let mut total_trading_balance: u64 = 0;
         let mut trader_positions = Vec::new();
         let mut closed_trader_positions = Vec::new();
+        let mut liquidated_trader_positions = Vec::new();
         let mut lend_positions = Vec::new();
         let mut on_chain_count = 0;
 
@@ -1877,6 +1878,31 @@ impl OrderWallet {
                                 }
 
                                 closed_trader_positions.push(summary);
+                            } else if order_v1.order.order_status == OrderStatus::LIQUIDATE {
+                                let summary =
+                                    super::portfolio::PositionSummary::from_trader_order_v1(
+                                        account.index,
+                                        &order_v1,
+                                        current_price,
+                                    );
+
+                                // Unlock the liquidated account (refresh UTXO, restore to Coin)
+                                match self.unlock_settled_order(account.index).await {
+                                    Ok(_) => {
+                                        info!(
+                                            "Unlocked liquidated account {} during portfolio scan",
+                                            account.index
+                                        );
+                                    }
+                                    Err(e) => {
+                                        error!(
+                                            "Failed to unlock liquidated account {}: {}",
+                                            account.index, e
+                                        );
+                                    }
+                                }
+
+                                liquidated_trader_positions.push(summary);
                             } else {
                                 trader_positions.push(
                                     super::portfolio::PositionSummary::from_trader_order_v1(
@@ -1916,6 +1942,7 @@ impl OrderWallet {
             total_trading_balance,
             trader_positions,
             closed_trader_positions,
+            liquidated_trader_positions,
             lend_positions,
             total_accounts,
             on_chain_count,

--- a/src/relayer_module/portfolio.rs
+++ b/src/relayer_module/portfolio.rs
@@ -217,7 +217,12 @@ impl Portfolio {
         on_chain_accounts: usize,
     ) -> Self {
         let total_margin_used: f64 = trader_positions.iter().map(|p| p.initial_margin).sum();
-        let unrealized_pnl: f64 = trader_positions.iter().map(|p| p.unrealized_pnl).sum();
+        // Exclude PENDING positions from PnL — they haven't been filled yet.
+        let unrealized_pnl: f64 = trader_positions
+            .iter()
+            .filter(|p| p.order_status != OrderStatus::PENDING)
+            .map(|p| p.unrealized_pnl)
+            .sum();
         let total_lend_deposits: f64 = lend_positions.iter().map(|p| p.deposit).sum();
         let total_lend_value: f64 = lend_positions.iter().map(|p| p.current_value).sum();
         // Prefer v1 unrealised PnL (computed from live pool TLV) when available

--- a/src/relayer_module/portfolio.rs
+++ b/src/relayer_module/portfolio.rs
@@ -194,8 +194,12 @@ pub struct Portfolio {
     pub total_lend_value: f64,
     /// Lend PnL (current value - deposits).
     pub lend_pnl: f64,
+    /// Sum of realised PnL across settled trader positions.
+    pub realised_pnl: f64,
     /// Open trader positions.
     pub trader_positions: Vec<PositionSummary>,
+    /// Settled (closed) trader positions unlocked during this summary.
+    pub closed_trader_positions: Vec<PositionSummary>,
     /// Active lend positions.
     pub lend_positions: Vec<LendPositionSummary>,
     /// Number of ZkOS accounts total.
@@ -212,6 +216,7 @@ impl Portfolio {
         wallet_balance_sats: u64,
         total_trading_balance: u64,
         trader_positions: Vec<PositionSummary>,
+        closed_trader_positions: Vec<PositionSummary>,
         lend_positions: Vec<LendPositionSummary>,
         total_accounts: usize,
         on_chain_accounts: usize,
@@ -237,6 +242,11 @@ impl Portfolio {
             total_lend_value - total_lend_deposits
         };
 
+        let realised_pnl: f64 = closed_trader_positions
+            .iter()
+            .map(|p| p.unrealized_pnl)
+            .sum();
+
         let denominator = total_trading_balance as f64 + total_margin_used;
         let margin_utilization = if denominator > 0.0 {
             total_margin_used / denominator
@@ -249,10 +259,12 @@ impl Portfolio {
             total_trading_balance,
             total_margin_used,
             unrealized_pnl,
+            realised_pnl,
             total_lend_deposits,
             total_lend_value,
             lend_pnl,
             trader_positions,
+            closed_trader_positions,
             lend_positions,
             total_accounts,
             on_chain_accounts,

--- a/src/relayer_module/portfolio.rs
+++ b/src/relayer_module/portfolio.rs
@@ -200,6 +200,10 @@ pub struct Portfolio {
     pub trader_positions: Vec<PositionSummary>,
     /// Settled (closed) trader positions unlocked during this summary.
     pub closed_trader_positions: Vec<PositionSummary>,
+    /// Liquidated trader positions.
+    pub liquidated_trader_positions: Vec<PositionSummary>,
+    /// Total loss from liquidated positions (sum of initial margins).
+    pub liquidation_loss: f64,
     /// Active lend positions.
     pub lend_positions: Vec<LendPositionSummary>,
     /// Number of ZkOS accounts total.
@@ -217,6 +221,7 @@ impl Portfolio {
         total_trading_balance: u64,
         trader_positions: Vec<PositionSummary>,
         closed_trader_positions: Vec<PositionSummary>,
+        liquidated_trader_positions: Vec<PositionSummary>,
         lend_positions: Vec<LendPositionSummary>,
         total_accounts: usize,
         on_chain_accounts: usize,
@@ -247,6 +252,11 @@ impl Portfolio {
             .map(|p| p.unrealized_pnl)
             .sum();
 
+        let liquidation_loss: f64 = liquidated_trader_positions
+            .iter()
+            .map(|p| p.initial_margin)
+            .sum();
+
         let denominator = total_trading_balance as f64 + total_margin_used;
         let margin_utilization = if denominator > 0.0 {
             total_margin_used / denominator
@@ -265,6 +275,8 @@ impl Portfolio {
             lend_pnl,
             trader_positions,
             closed_trader_positions,
+            liquidated_trader_positions,
+            liquidation_loss,
             lend_positions,
             total_accounts,
             on_chain_accounts,

--- a/src/relayer_module/relayer_api.rs
+++ b/src/relayer_module/relayer_api.rs
@@ -28,7 +28,7 @@ use jsonrpsee::rpc_params;
 use serde::{Deserialize, Serialize};
 use twilight_client_sdk::relayer_types::{
     CancelTraderOrderZkos, CreateLendOrderZkos, CreateTraderOrderClientZkos, ExecuteLendOrderZkos,
-    ExecuteTraderOrderZkos, QueryLendOrderZkos, QueryTraderOrderZkos,
+    ExecuteTraderOrderZkos, ExecuteTraderOrderZkosSlTp, QueryLendOrderZkos, QueryTraderOrderZkos,
 };
 
 /// Wrapper for hex-encoded binary data sent to relayer endpoints.
@@ -269,6 +269,18 @@ impl RelayerJsonRpcClient {
             .await
     }
 
+    pub async fn settle_trade_order_sltp(
+        &self,
+        tx: ExecuteTraderOrderZkosSlTp,
+    ) -> Result<RequestResponse, RpcError> {
+        let params = HexEncodedData {
+            data: tx.encode_as_hex_string(),
+        };
+        self.client
+            .request("settle_trade_order", AsRpcParams(params))
+            .await
+    }
+
     pub async fn settle_lend_order(
         &self,
         tx: ExecuteLendOrderZkos,
@@ -312,9 +324,7 @@ impl RelayerJsonRpcClient {
 
     /// Get APY chart data points for visualization.
     pub async fn apy_chart(&self, params: ApyChartArgs) -> Result<Vec<ApyChartPoint>, RpcError> {
-        self.client
-            .request("apy_chart", AsRpcParams(params))
-            .await
+        self.client.request("apy_chart", AsRpcParams(params)).await
     }
 
     // -------------------------
@@ -328,9 +338,7 @@ impl RelayerJsonRpcClient {
 
     /// Get comprehensive market risk statistics.
     pub async fn get_market_stats(&self) -> Result<MarketStats, RpcError> {
-        self.client
-            .request("get_market_stats", rpc_params![])
-            .await
+        self.client.request("get_market_stats", rpc_params![]).await
     }
 
     // -------------------------

--- a/src/relayer_module/relayer_order.rs
+++ b/src/relayer_module/relayer_order.rs
@@ -9,8 +9,8 @@ use twilight_client_sdk::{
     },
     relayer_types::{
         CancelTraderOrderZkos, CreateLendOrderZkos, CreateTraderOrderClientZkos,
-        ExecuteLendOrderZkos, ExecuteTraderOrderZkos, OrderStatus, OrderType, PositionType,
-        SlTpOrder, TXType,
+        ExecuteLendOrderZkos, ExecuteTraderOrderZkos, ExecuteTraderOrderZkosSlTp, OrderStatus,
+        OrderType, PositionType, SlTpOrder, TXType,
     },
     util::create_output_memo_for_lender,
     zkvm::Output,
@@ -120,7 +120,7 @@ pub async fn close_trader_order_sltp_internal(
         Some(SlTpOrder::new(stop_loss_price, take_profit_price)),
     );
     let response = relayer_api_client
-        .settle_trade_order(ExecuteTraderOrderZkos::decode_from_hex_string(
+        .settle_trade_order_sltp(ExecuteTraderOrderZkosSlTp::decode_from_hex_string(
             request_msg.clone(),
         )?)
         .await

--- a/src/relayer_module/utils.rs
+++ b/src/relayer_module/utils.rs
@@ -12,7 +12,9 @@ use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
 use tokio::time::{sleep, Duration};
 use twilight_client_sdk::{
-    relayer_rpcclient::method::UtxoDetailResponse, relayer_types::TxHash, zkvm::IOType,
+    relayer_rpcclient::method::UtxoDetailResponse,
+    relayer_types::{OrderStatus, TxHash},
+    zkvm::IOType,
 };
 
 // Retry configuration constants
@@ -165,6 +167,41 @@ pub async fn fetch_tx_hash_with_retry(
             .transaction_hashes(TransactionHashArgs::RequestId {
                 id: request_id.to_string(),
                 status: None,
+                limit: None,
+                offset: None,
+            })
+            .await
+            .map_err(|e| e.to_string())?;
+        if response.is_empty() {
+            attempts += 1;
+            if attempts >= TXHASH_ATTEMPTS {
+                return Err(format!(
+                    "Failed to get tx hash after {} attempts",
+                    TXHASH_ATTEMPTS
+                ));
+            }
+            sleep(retry_delay(attempts)).await;
+        } else {
+            let latest_tx = response
+                .iter()
+                .max_by_key(|tx| (tx.datetime.trim().parse::<i64>().unwrap_or(i64::MIN), tx.id))
+                .unwrap_or(&response[0]);
+
+            return Ok(latest_tx.clone());
+        }
+    }
+}
+pub async fn fetch_tx_hash_with_account_address_retry(
+    account_address: &str,
+    order_status: Option<OrderStatus>,
+    relayer_api_client: &RelayerJsonRpcClient,
+) -> Result<TxHash, String> {
+    let mut attempts = 0;
+    loop {
+        let response = relayer_api_client
+            .transaction_hashes(TransactionHashArgs::AccountId {
+                id: account_address.to_string(),
+                status: order_status.clone(),
                 limit: None,
                 offset: None,
             })


### PR DESCRIPTION
## Summary
- **Wallet auth simplification**: Resolve `wallet_id` and `password` from env vars (`NYKS_WALLET_ID`, `NYKS_WALLET_PASSPHRASE`) with `wallet unlock/lock` session caching via parent shell PID
- **CLI restructure**: Extract `zkaccount` subcommand (fund/withdraw/transfer/split) from `order`, add 5 missing market data commands (pool-share-value, last-day-apy, open-interest, market-stats, server-time)
- **Portfolio enhancements**: Mark price in summary header, per-position columns (status, margin, fees, funding, limit/TP/SL), PENDING orders show `-` for PnL, auto-detect and unlock SETTLED and LIQUIDATED positions with realised PnL and liquidation loss tracking
- **SLTP fix**: `close_trader_order_sltp` no longer blocks waiting for settlement — returns after order acceptance
- **New command**: `order unlock-trade` to manually reclaim accounts after SLTP settlement
- **Bug fixes**: macOS-compatible `getppid()`/`kill()`, TOCTOU fix in session file creation, proper error on missing wallet_id
- **Docs**: Full rewrite of `relayer-cli.md` covering all commands, flags, env vars, and output formats

## Test plan
- [ ] Verify `wallet unlock` / `wallet lock` caches and clears password for the terminal session
- [ ] Confirm `NYKS_WALLET_ID` and `NYKS_WALLET_PASSPHRASE` env vars are picked up when flags are omitted
- [ ] Test `zkaccount fund/withdraw/transfer/split` commands work under the new subcommand
- [ ] Run `portfolio summary` and verify settled positions appear in "Closed Positions" section with realised PnL
- [ ] Run `portfolio summary` and verify liquidated positions appear in "Liquidated Positions" section with loss
- [ ] Test `order unlock-trade --account-index N` on a settled SLTP order
- [ ] Verify `order close-trade --stop-loss X --take-profit Y` returns promptly without blocking
- [ ] Check all new market commands return formatted output