### PR TITLE
Fix TTY fallback for headless environments and improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,21 @@ WORKDIR /home/relayer
 COPY --from=builder /workspace/target/release/relayer-init /usr/local/bin/relayer-init
 COPY --from=builder /workspace/target/release/relayer-cli /usr/local/bin/relayer-cli
 
+# Copy the relayer program JSON and env example for reference
+COPY --from=builder /workspace/relayerprogram.json /home/relayer/relayerprogram.json
+COPY --from=builder /workspace/.env.example /home/relayer/.env.example
+
 # Switch to the non-root user
 USER relayer
 
-# The program expects several environment variables.
-# You can provide them at `docker run` time.
-# Example:
-#   docker run -e ZKOS_SERVER_URL=https://zkos-rpc.twilight.rest ... relayer-init
+# Default environment for testnet
+ENV NYKS_LCD_BASE_URL=https://lcd.twilight.rest \
+    NYKS_RPC_BASE_URL=https://rpc.twilight.rest \
+    FAUCET_BASE_URL=https://faucet-rpc.twilight.rest \
+    ZKOS_SERVER_URL=https://nykschain.twilight.rest/zkos \
+    RELAYER_API_RPC_SERVER_URL=https://relayer.twilight.rest/api \
+    RELAYER_PROGRAM_JSON_PATH=./relayerprogram.json \
+    RUST_LOG=info
 
-ENTRYPOINT ["relayer-init"] 
+# Default to the CLI; override with `docker run <image> relayer-init` if needed
+ENTRYPOINT ["relayer-cli"]

--- a/src/security/secure_tty.rs
+++ b/src/security/secure_tty.rs
@@ -17,11 +17,18 @@ fn open_tty() -> Result<std::fs::File> {
 /// Print a secret directly to the terminal device (never stdout/stderr),
 /// then zeroize the buffer. If no TTY is attached, returns an error and prints nothing.
 pub fn print_secret_to_tty(secret: &mut String) -> Result<()> {
-    let mut tty = open_tty()?;
-    // write line + flush; DO NOT println!/eprintln!
-    tty.write_all(secret.as_bytes())?;
-    tty.write_all(b"\n")?;
-    tty.flush()?;
+    match open_tty() {
+        Ok(mut tty) => {
+            // write line + flush; DO NOT println!/eprintln!
+            tty.write_all(secret.as_bytes())?;
+            tty.write_all(b"\n")?;
+            tty.flush()?;
+        }
+        Err(_) => {
+            // No TTY available — print to stderr as fallback
+            eprintln!("{secret}");
+        }
+    }
 
     // wipe caller-owned buffer
     secret.zeroize();


### PR DESCRIPTION
## Summary
- **TTY fallback**: `print_secret_to_tty` now falls back to stderr when `/dev/tty` is unavailable (Docker, CI, background processes) instead of returning an error that aborts wallet creation with "Device not configured (os error 6)".
- **Dockerfile improvements**: Copy `relayerprogram.json` and `.env.example` into the image, set default testnet environment variables, and default the entrypoint to `relayer-cli`.

## Test plan
- [ ] Run `relayer-cli wallet create` inside a Docker container (no TTY) — should succeed and print mnemonic to stderr
- [ ] Run `relayer-cli wallet create` in an interactive terminal — should still print mnemonic to `/dev/tty` as before
- [ ] Build Docker image and verify `relayer-cli help` works with default env vars