### PR TITLE
Update default endpoints to mainnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,16 +16,33 @@ NETWORK_TYPE=testnet # The type of network: testnet or mainnet
 # =============================================================================
 # These are the URLs for various services the wallet interacts with.
 
-# Local development endpoints, need to be changed for production environment
-FAUCET_BASE_URL=http://0.0.0.0:6969 # Faucet for test tokens
-NYKS_LCD_BASE_URL=http://0.0.0.0:1317 # Nyks chain Light Client Daemon (LCD) endpoint
-NYKS_RPC_BASE_URL=http://0.0.0.0:26657 # Nyks chain RPC endpoint
+# ---------------------------------------------------------------------------
+# Local development endpoints (uncomment for local dev)
+# ---------------------------------------------------------------------------
+# FAUCET_BASE_URL=http://0.0.0.0:6969
+# NYKS_LCD_BASE_URL=http://0.0.0.0:1317
+# NYKS_RPC_BASE_URL=http://0.0.0.0:26657
+# RELAYER_API_RPC_SERVER_URL=http://0.0.0.0:8088/api
+# PUBLIC_API_RPC_SERVER_URL=http://0.0.0.0:8088/api
+# RELAYER_RPC_SERVER_URL=http://0.0.0.0:3032
+# ZKOS_SERVER_URL=http://0.0.0.0:3030
 
-# Order-wallet feature endpoints, required for order-wallet feature
-RELAYER_API_RPC_SERVER_URL=http://0.0.0.0:8088/api # Relayer public API endpoint (required for order-wallet)
-PUBLIC_API_RPC_SERVER_URL=http://0.0.0.0:8088/api # Public API endpoint (can be same as relayer, required for order-wallet)
-RELAYER_RPC_SERVER_URL=http://0.0.0.0:3032 # Relayer client API endpoint (required for order-wallet)
-ZKOS_SERVER_URL=http://0.0.0.0:3030 # zkos server endpoint for zero-knowledge operations (required for bin relayer-init also)
+# ---------------------------------------------------------------------------
+# Testnet endpoints
+# ---------------------------------------------------------------------------
+# FAUCET_BASE_URL=https://faucet-rpc.twilight.rest
+# NYKS_LCD_BASE_URL=https://lcd.twilight.rest
+# NYKS_RPC_BASE_URL=https://rpc.twilight.rest
+# RELAYER_API_RPC_SERVER_URL=https://relayer.twilight.rest/api
+# ZKOS_SERVER_URL=https://nykschain.twilight.rest/zkos
+
+# ---------------------------------------------------------------------------
+# Mainnet endpoints (active)
+# ---------------------------------------------------------------------------
+NYKS_LCD_BASE_URL=https://lcd.twilight.org
+NYKS_RPC_BASE_URL=https://rpc.twilight.org
+RELAYER_API_RPC_SERVER_URL=https://api.ephemeral.fi/api
+ZKOS_SERVER_URL=https://zkserver.twilight.org
 
 # =============================================================================
 # WALLET CONFIGURATION

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,17 +4,17 @@ use std::sync::LazyLock;
 pub static FAUCET_BASE_URL: LazyLock<String> =
     LazyLock::new(|| std::env::var("FAUCET_BASE_URL").unwrap_or("http://0.0.0.0:6969".to_string()));
 pub static NYKS_LCD_BASE_URL: LazyLock<String> =
-    LazyLock::new(|| std::env::var("NYKS_LCD_BASE_URL").unwrap_or("http://0.0.0.0:1317".to_string()));
+    LazyLock::new(|| std::env::var("NYKS_LCD_BASE_URL").unwrap_or("https://lcd.twilight.org".to_string()));
 pub static NYKS_RPC_BASE_URL: LazyLock<String> =
-    LazyLock::new(|| std::env::var("NYKS_RPC_BASE_URL").unwrap_or("http://0.0.0.0:26657".to_string()));
+    LazyLock::new(|| std::env::var("NYKS_RPC_BASE_URL").unwrap_or("https://rpc.twilight.org".to_string()));
 pub static VALIDATOR_WALLET_PATH: LazyLock<String> =
     LazyLock::new(|| std::env::var("VALIDATOR_WALLET_PATH").unwrap_or("validator.mnemonic".to_string()));
 pub static RELAYER_PROGRAM_JSON_PATH: LazyLock<String> =
     LazyLock::new(|| std::env::var("RELAYER_PROGRAM_JSON_PATH").unwrap_or_else(|_| "./relayerprogram.json".to_string()));
 pub static ZKOS_SERVER_URL: LazyLock<String> =
-    LazyLock::new(|| std::env::var("ZKOS_SERVER_URL").unwrap_or("http://0.0.0.0:3030".to_string()));
+    LazyLock::new(|| std::env::var("ZKOS_SERVER_URL").unwrap_or("https://zkserver.twilight.org".to_string()));
 pub static RELAYER_API_RPC_SERVER_URL: LazyLock<String> =
-    LazyLock::new(|| std::env::var("RELAYER_API_RPC_SERVER_URL").unwrap_or("http://0.0.0.0:8088/api".to_string()));
+    LazyLock::new(|| std::env::var("RELAYER_API_RPC_SERVER_URL").unwrap_or("https://api.ephemeral.fi/api".to_string()));
 pub static CHAIN_ID: LazyLock<String> =
     LazyLock::new(|| std::env::var("CHAIN_ID").unwrap_or("nyks".to_string()));
 /// Network type: "testnet" or "mainnet". Controls BIP-44 coin type (1 vs 118).


### PR DESCRIPTION
## Summary
- **`src/config.rs`**: Change hardcoded fallback URLs from localhost to mainnet endpoints:
  - `lcd.twilight.org` (LCD)
  - `rpc.twilight.org` (RPC)
  - `zkserver.twilight.org` (ZkOS)
  - `api.ephemeral.fi/api` (Relayer API)
- **`.env.example`**: Reorganize into local/testnet/mainnet sections with mainnet active by default

Previously the defaults pointed to `0.0.0.0` which meant the CLI would fail silently or error out if no `.env` file was present.

## Test plan
- [ ] Build without a `.env` file and verify `relayer-cli market price` hits mainnet
- [ ] Verify `.env` overrides still take precedence over the new defaults
- [ ] Verify testnet works when uncommenting testnet section in `.env.example`