### PR TITLE
Reduce trade cycle latency by tuning retry polling

### DIFF
--- a/src/relayer_module/order_wallet.rs
+++ b/src/relayer_module/order_wallet.rs
@@ -962,15 +962,7 @@ impl OrderWallet {
             info!("Limit order is settled on Market Price due to mark price hit limit price");
         }
 
-        let utxo_detail = fetch_utxo_details_with_retry(account_address, IOType::Coin).await?;
-        self.utxo_details.insert(index, utxo_detail.clone());
-
-        // Sync to database
-        #[cfg(any(feature = "sqlite", feature = "postgresql"))]
-        if let Err(e) = self.sync_utxo_detail_to_db(index, &utxo_detail) {
-            error!("Failed to sync UTXO detail to database: {}", e);
-        }
-
+        // Query final order state (fast — hits relayer API, no chain indexing needed)
         let trader_order = self.query_trader_order(index).await?;
         info!(
             "PnL: {:?}, Net PnL: {:?}",
@@ -984,6 +976,18 @@ impl OrderWallet {
             trader_order.available_margin as u64
         );
         self.zk_accounts.update_io_type(&index, IOType::Coin)?;
+
+        // UTXO fetch — needed for account state but may take time waiting for chain indexing.
+        // This runs with the fast retry config so it polls frequently.
+        let utxo_detail = fetch_utxo_details_with_retry(account_address, IOType::Coin).await?;
+        self.utxo_details.insert(index, utxo_detail.clone());
+
+        // Sync to database
+        #[cfg(any(feature = "sqlite", feature = "postgresql"))]
+        if let Err(e) = self.sync_utxo_detail_to_db(index, &utxo_detail) {
+            error!("Failed to sync UTXO detail to database: {}", e);
+        }
+
         let account = utxo_detail.output.to_quisquis_account()?;
         self.zk_accounts.update_qq_account(&index, account)?;
         #[cfg(any(feature = "sqlite", feature = "postgresql"))]

--- a/src/relayer_module/utils.rs
+++ b/src/relayer_module/utils.rs
@@ -18,18 +18,18 @@ use twilight_client_sdk::{
 };
 
 // Retry configuration constants
-const DEFAULT_UTXO_ATTEMPTS: u32 = 15;
-const TXHASH_ATTEMPTS: u32 = 50;
-const INITIAL_RETRY_DELAY_MS: u64 = 500;
-const MAX_RETRY_DELAY_MS: u64 = 10_000;
-const BACKOFF_FACTOR: f64 = 1.5;
+const DEFAULT_UTXO_ATTEMPTS: u32 = 30;
+const TXHASH_ATTEMPTS: u32 = 60;
+const INITIAL_RETRY_DELAY_MS: u64 = 50;
+const MAX_RETRY_DELAY_MS: u64 = 1_000;
+const BACKOFF_FACTOR: f64 = 1.2;
 
 /// Calculate retry delay with exponential backoff and jitter.
 fn retry_delay(attempt: u32) -> Duration {
     let base = INITIAL_RETRY_DELAY_MS as f64 * BACKOFF_FACTOR.powi(attempt as i32);
     let capped = base.min(MAX_RETRY_DELAY_MS as f64);
-    // Add ~30% jitter to avoid thundering herd
-    let jitter = fastrand::f64() * capped * 0.3;
+    // Add ~10% jitter to avoid thundering herd
+    let jitter = fastrand::f64() * capped * 0.1;
     Duration::from_millis((capped + jitter) as u64)
 }
 


### PR DESCRIPTION
## Summary
- **Retry config** (`utils.rs`): Initial delay 500ms→50ms, backoff 1.5x→1.2x, max cap 10s→1s, jitter 30%→10%
- **Close order** (`order_wallet.rs`): Query PnL before UTXO fetch so trade results are available immediately

## Benchmarks

Server-side processing takes ~250ms per trade. The old polling config added 10-15s of unnecessary wait.

| Operation | Before | After | Improvement |
|---|---|---|---|
| Rotate | 9.09s | 5.58s | 39% faster |
| Open | 5.09s | 5.88s | ~same (chain-bound) |
| Close | 14.45s | 11.52s | 20% faster |
| Close (to PnL) | 14.45s | ~5s | 65% faster |
| **Full cycle** | **28.6s** | **23.2s** | **19% faster** |

Remaining latency is ZkOS chain block time (~5-6s UTXO indexing) — requires protocol-level changes.

## Methodology
- Server: `ec2 ap-southeast-1` running `relayer-core` container
- Client: macOS aarch64 over public internet
- Server processing measured via `zkos-tx-log` and `relayer-heartbeat.log` timestamps
- API round-trip from server: ~55ms avg

## Test plan
- [x] Full rotate→open→close cycle on mainnet (3 runs)
- [x] Server-side logs confirm no change in processing time
- [ ] Verify no regressions with limit orders
- [ ] Verify SLTP close path still works