### PR TITLE
Add self-update feature and install scripts for relayer-cli

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [created, published]
+    types: [published]
 
 concurrency:
   group: release-${{ github.ref }}
@@ -15,32 +15,67 @@ permissions:
   contents: write
 
 jobs:
+  verify-version:
+    if: contains(github.event.release.tag_name, '-relayer-cli')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify Cargo.toml version matches release tag
+        shell: bash
+        run: |
+          set -e
+          TAG="${{ github.event.release.tag_name }}"
+          TAG_VERSION="${TAG%-relayer-cli}"
+          TAG_VERSION="${TAG_VERSION#v}"
+          CARGO_VERSION=$(grep -E '^version = "' Cargo.toml | head -1 | sed -E 's/^version = "(.+)"$/\1/')
+          echo "Tag version:   $TAG_VERSION"
+          echo "Cargo version: $CARGO_VERSION"
+          if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Cargo.toml version ($CARGO_VERSION) does not match tag version ($TAG_VERSION). Bump Cargo.toml before tagging."
+            exit 1
+          fi
+
   build-and-upload:
+    needs: verify-version
+    if: contains(github.event.release.tag_name, '-relayer-cli')
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            artifact: nyks-wallet-linux-amd64
+            artifact_suffix: relayer_cli_linux_amd64
             binary: target/x86_64-unknown-linux-gnu/release/relayer-cli
+            label: "Relayer CLI Linux amd64"
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            artifact: nyks-wallet-linux-arm64
+            artifact_suffix: relayer_cli_linux_arm64
             binary: target/aarch64-unknown-linux-gnu/release/relayer-cli
+            label: "Relayer CLI Linux arm64"
           - os: macos-latest
             target: aarch64-apple-darwin
-            artifact: nyks-wallet-macos-arm64
+            artifact_suffix: relayer_cli_macos_arm64
             binary: target/aarch64-apple-darwin/release/relayer-cli
+            label: "Relayer CLI macOS arm64"
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            artifact: nyks-wallet-windows-amd64.exe
+            artifact_suffix: relayer_cli_windows_amd64.exe
             binary: target/x86_64-pc-windows-msvc/release/relayer-cli.exe
+            label: "Relayer CLI Windows amd64"
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set artifact name
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG%-relayer-cli}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=nw_${VERSION}_${{ matrix.artifact_suffix }}" >> $GITHUB_ENV
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
@@ -92,27 +127,31 @@ jobs:
       - name: Prepare binary artifact (Unix)
         if: runner.os != 'Windows'
         run: |
-          cp ${{ matrix.binary }} ${{ matrix.artifact }}
-          chmod +x ${{ matrix.artifact }}
+          cp ${{ matrix.binary }} ${{ env.ARTIFACT_NAME }}
+          chmod +x ${{ env.ARTIFACT_NAME }}
 
       - name: Prepare binary artifact (Windows)
         if: runner.os == 'Windows'
-        run: cp ${{ matrix.binary }} ${{ matrix.artifact }}
+        run: cp ${{ matrix.binary }} ${{ env.ARTIFACT_NAME }}
 
       - name: Generate SHA256 checksum (Unix)
         if: runner.os != 'Windows'
-        run: shasum -a 256 ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
+        run: shasum -a 256 ${{ env.ARTIFACT_NAME }} > ${{ env.ARTIFACT_NAME }}.sha256
 
       - name: Generate SHA256 checksum (Windows)
         if: runner.os == 'Windows'
         shell: powershell
         run: |
-          $hash = (Get-FileHash "${{ matrix.artifact }}" -Algorithm SHA256).Hash.ToLower()
-          "$hash  ${{ matrix.artifact }}" | Out-File -Encoding ascii "${{ matrix.artifact }}.sha256"
+          $hash = (Get-FileHash "${{ env.ARTIFACT_NAME }}" -Algorithm SHA256).Hash.ToLower()
+          "$hash  ${{ env.ARTIFACT_NAME }}" | Out-File -Encoding ascii "${{ env.ARTIFACT_NAME }}.sha256"
 
       - name: Upload binary to release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            ${{ matrix.artifact }}
-            ${{ matrix.artifact }}.sha256
+        shell: bash
+        run: |
+          set -e
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "${{ env.ARTIFACT_NAME }}#${{ matrix.label }} ${{ env.VERSION }}" \
+            "${{ env.ARTIFACT_NAME }}.sha256#SHA256 checksum for ${{ matrix.label }} ${{ env.VERSION }}" \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,10 @@ jobs:
             target: x86_64-unknown-linux-gnu
             artifact: nyks-wallet-linux-amd64
             binary: target/x86_64-unknown-linux-gnu/release/relayer-cli
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            artifact: nyks-wallet-linux-arm64
+            binary: target/aarch64-unknown-linux-gnu/release/relayer-cli
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: nyks-wallet-macos-arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,7 +99,20 @@ jobs:
         if: runner.os == 'Windows'
         run: cp ${{ matrix.binary }} ${{ matrix.artifact }}
 
+      - name: Generate SHA256 checksum (Unix)
+        if: runner.os != 'Windows'
+        run: shasum -a 256 ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
+
+      - name: Generate SHA256 checksum (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          $hash = (Get-FileHash "${{ matrix.artifact }}" -Algorithm SHA256).Hash.ToLower()
+          "$hash  ${{ matrix.artifact }}" | Out-File -Encoding ascii "${{ matrix.artifact }}.sha256"
+
       - name: Upload binary to release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ matrix.artifact }}
+          files: |
+            ${{ matrix.artifact }}
+            ${{ matrix.artifact }}.sha256

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ examples/trading_bot/mnomenics_key
 env.example
 Audit_report_and_Suggetions.md
 test_cli.sh
+test_help_responses.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ bdk_esplora = { version = "0.22", default-features = false, features = [
 ] }
 aes-gcm = "0.10"
 clap = { version = "4", features = ["derive"] }
+self-replace = "1"
 libc = "0.2"
 qr2term = "0.3"
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -39,33 +39,44 @@ The resulting binary will be at `target/release/relayer-init`.
 
 ## 3. Configure endpoints
 
-`relayer-init` talks to several Twilight test-net services. Endpoints are looked up via environment variables and **panic if they are not set**.
+`relayer-init` talks to several Twilight services. Endpoint defaults are picked by `NETWORK_TYPE` (mainnet vs testnet) — nothing is required; override only what you need.
 
-| Variable            | Default value                                                        | Notes                          |
-| ------------------- | -------------------------------------------------------------------- | ------------------------------ |
-| `NYKS_LCD_BASE_URL` | `http://0.0.0.0:1317` (public: https://lcd.twilight.rest)            | NYKS chain LCD (REST) endpoint |
-| `NYKS_RPC_BASE_URL` | `http://0.0.0.0:26657` (public: https://rpc.twilight.rest)           | NYKS chain RPC endpoint        |
-| `FAUCET_BASE_URL`   | `http://0.0.0.0:6969` (public: https://faucet-rpc.twilight.rest)     | Nyks / BTC faucet services     |
-| `ZKOS_SERVER_URL`   | `http://0.0.0.0:3030` (public: https://nykschain.twilight.rest/zkos) | ZkOS JSON-RPC endpoint         |
-| `RUST_LOG`          | `info`                                                               | Logging info                   |
+| Variable                     | Default (selected by `NETWORK_TYPE`)                                                   | Notes                          |
+| ---------------------------- | -------------------------------------------------------------------------------------- | ------------------------------ |
+| `NETWORK_TYPE`               | `mainnet`                                                                              | set `testnet` to use `*.twilight.rest` defaults |
+| `BTC_NETWORK_TYPE`           | `mainnet`                                                                              | nyks chain only supports BTC mainnet — keep as `mainnet` |
+| `CHAIN_ID`                   | `nyks`                                                                                 | Chain identifier in signed messages |
+| `NYKS_LCD_BASE_URL`          | mainnet: `https://lcd.twilight.org` / testnet: `https://lcd.twilight.rest`             | NYKS chain LCD (REST) endpoint |
+| `NYKS_RPC_BASE_URL`          | mainnet: `https://rpc.twilight.org` / testnet: `https://rpc.twilight.rest`             | NYKS chain Tendermint RPC      |
+| `FAUCET_BASE_URL`            | mainnet: *(empty)* / testnet: `https://faucet-rpc.twilight.rest`                       | Testnet faucet (testnet only)  |
+| `ZKOS_SERVER_URL`            | mainnet: `https://zkserver.twilight.org` / testnet: `https://nykschain.twilight.rest/zkos` | ZkOS JSON-RPC endpoint     |
+| `RELAYER_API_RPC_SERVER_URL` | mainnet: `https://api.ephemeral.fi/api` / testnet: `https://relayer.twilight.rest/api` | Relayer public JSON-RPC API    |
+| `RELAYER_PROGRAM_JSON_PATH`  | `./relayerprogram.json`                                                                | Path to relayer program JSON   |
+| `RUST_LOG`                   | –                                                                                      | Logging level                  |
+
+See [`README.md §7`](README.md#7--environment-variables) for the complete list (including indexer, Esplora, DB, and wallet-passphrase variables).
 
 ### 3.1 Create a `.env` file (recommended)
 
 ```bash
 cat <<'EOF' > .env
-NYKS_LCD_BASE_URL=http://0.0.0.0:1317
-NYKS_RPC_BASE_URL=http://0.0.0.0:26657
-FAUCET_BASE_URL=http://0.0.0.0:6969
-ZKOS_SERVER_URL=http://0.0.0.0:3030
+NETWORK_TYPE=testnet
+BTC_NETWORK_TYPE=mainnet
+CHAIN_ID=nyks
 RUST_LOG=info
-
+# Override individual endpoints only if pointing at a local full-node:
+# NYKS_LCD_BASE_URL=http://0.0.0.0:1317
+# NYKS_RPC_BASE_URL=http://0.0.0.0:26657
+# FAUCET_BASE_URL=http://0.0.0.0:6969
+# ZKOS_SERVER_URL=http://0.0.0.0:3030
+# RELAYER_API_RPC_SERVER_URL=http://0.0.0.0:8088/api
 EOF
 ```
 
 Load it in your shell:
 
 ```bash
-source .env
+set -a; source .env; set +a
 ```
 
 ### 3.2 One-off override
@@ -73,10 +84,8 @@ source .env
 You can also pass variables inline for a single execution:
 
 ```bash
-ZKOS_SERVER_URL=https://nykschain.twilight.rest/zkos \
-NYKS_LCD_BASE_URL=https://lcd.twilight.rest \
-NYKS_RPC_BASE_URL=https://rpc.twilight.rest \
-FAUCET_BASE_URL=https://faucet-rpc.twilight.rest \
+NETWORK_TYPE=testnet \
+BTC_NETWORK_TYPE=mainnet \
 RUST_LOG=info \
 cargo run --bin relayer-init
 ```

--- a/OrderFlow.md
+++ b/OrderFlow.md
@@ -39,7 +39,8 @@ follow the .env.example file
 ```rust
 use nyks_wallet::relayer_module::order_wallet::OrderWallet;
 
-// Defaults to Twilight testnet endpoints via EndpointConfig::default()
+// Defaults come from EndpointConfig::default() and depend on NETWORK_TYPE
+// (mainnet is picked when NETWORK_TYPE is unset — set NETWORK_TYPE=testnet for testnet).
 let mut order_wallet = OrderWallet::new(None)?;
 
 // Optional: import from mnemonic

--- a/OrderWallet.md
+++ b/OrderWallet.md
@@ -40,9 +40,11 @@ OrderWallet integrates seamlessly with Twilight relayer infrastructure for high-
 ### 2.1 Trading Capabilities
 
 - **Market & Limit Orders** – instant execution or conditional fills
-- **Leveraged Positions** – configurable leverage up to 1–50x with validations
-- **Position Management** – programmatic open/close/cancel operations
-- **Real-time Order Status** – query pending, filled, and settled states
+- **Leveraged Positions** – leverage bounded at runtime by the relayer risk engine (`params.max_leverage` from `get_market_stats`)
+- **Position Management** – programmatic open/close/cancel, including stop-loss / take-profit variants
+- **Pre-submission Risk Validation** – `validate_open_order` replicates server-side checks (market status, max leverage, min position size, per-position cap, directional headroom)
+- **Real-time Order Status** – query pending, filled, settled, and v1 enhanced views (settle_limit, stop_loss, take_profit, funding_applied)
+- **History** – historical trader/lend orders and funding payment history
 
 ### 2.2 Lending Operations
 
@@ -215,14 +217,16 @@ async fn main() -> Result<(), String> {
 
 ```rust
 pub struct OrderWallet {
-    pub wallet: Wallet,                                    // Base wallet for chain operations
-    pub zk_accounts: ZkAccountDB,                         // ZK account database
-    pub chain_id: String,                                 // Target chain identifier
-    seed: SecretString,                                   // Seed for ZK key derivation
+    pub wallet: Wallet,                                          // Base wallet for chain operations
+    pub zk_accounts: ZkAccountDB,                                // ZK account database
+    pub chain_id: String,                                        // Target chain identifier
+    seed: SecretString,                                          // Seed for ZK key derivation (private)
     pub utxo_details: HashMap<AccountIndex, UtxoDetailResponse>, // UTXO tracking
-    pub request_ids: HashMap<AccountIndex, String>,       // Order request tracking
-    pub relayer_api_client: RelayerJsonRpcClient,         // Relayer RPC client
-    pub relayer_endpoint_config: RelayerEndPointConfig,   // Relayer endpoints/config
+    pub request_ids: HashMap<AccountIndex, RequestId>,           // Order request tracking
+    pub relayer_api_client: RelayerJsonRpcClient,                // Relayer RPC client
+    pub relayer_endpoint_config: RelayerEndPointConfig,          // Relayer endpoints/config
+    pub nonce_manager: Arc<NonceManager>,                        // Sequence/account_number manager
+    // Database fields are only present under `sqlite` or `postgresql` features.
 }
 ```
 
@@ -230,15 +234,21 @@ pub struct OrderWallet {
 
 - `OrderWallet::new(endpoint_config: Option<EndpointConfig>) -> Result<Self, WalletError>`
 - `OrderWallet::import_from_mnemonic(mnemonic: &str, endpoint_config: Option<EndpointConfig>) -> Result<Self, String>`
-- With DB features: `with_db(password: Option<SecretString>, wallet_id: Option<String>) -> Result<Self, String>`
-- With DB features: `load_from_db(wallet_id: String, password: Option<SecretString>, db_url: Option<String>) -> Result<Self, String>`
+- With DB features: `with_db(&mut self, password: Option<SecretString>, wallet_id: Option<String>) -> Result<Self, String>`
+- With DB features: `load_from_db(wallet_id: String, password: Option<SecretString>, db_url: Option<String>) -> Result<OrderWallet, String>`
 - With DB features: `get_wallet_list_from_db(db_url: Option<String>) -> Result<Vec<WalletList>, String>`
+- With DB features: `get_wallet_id_from_db(wallet_id: &str, db_url: Option<String>) -> Result<bool, String>`
+- With DB features: `get_db_manager(&self) -> Option<&DatabaseManager>`
+- With DB features: `get_wallet_password(&self) -> Option<&SecretString>`
 
 ### 5.3 Utility methods
 
-- `get_secret_key(index) -> RistrettoSecretKey`
-- `request_id(index) -> Result<&str, String>`
-- `ensure_coin_onchain(index) -> Result<(), String>`
+- `get_secret_key(index) -> RistrettoSecretKey` – derive a child key for an account index
+- `request_id(index) -> Result<&str, String>` – last stored request ID for an account
+- `ensure_coin_onchain(index) -> Result<(), String>` – check on-chain Coin state + non-zero balance
+- `ensure_zk_account_onchain(&ZkAccount) -> Result<(), String>` – same check given an account reference
+- `sync_nonce(&self) -> Result<(), String>` – re-anchor the local sequence counter from chain; call before transaction batches or periodically
+- `sync_account_state(&mut self, index) -> Result<(), String>` – refresh the on-chain UTXO state for an account; use this to complete a deferred sync after a `--no-wait` open/close
 
 ### 5.4 Funding and transfers
 
@@ -300,7 +310,7 @@ async fn main() -> Result<(), String> {
             OrderType::MARKET,
             PositionType::LONG,
             50_000, // entry price (> 0)
-            10,     // leverage 1..=50
+            10,     // leverage: must be > 0; upper bound enforced by risk engine
         )
         .await?;
 
@@ -311,15 +321,31 @@ async fn main() -> Result<(), String> {
 
 Validations:
 
-- `leverage` must be between 1 and 50
-- `entry_price` must be greater than 0
+- `leverage` must be greater than 0 (upper bound is enforced dynamically by the relayer risk engine against `params.max_leverage` in `get_market_stats`)
 - Account must be on-chain in Coin state
+- Pre-submission pipeline (via `validate_open_order`) mirrors the server-side risk engine and rejects the call before any RPC if it would fail:
+  1. Market status (HALT / CLOSE_ONLY)
+  2. Max leverage (`params.max_leverage`)
+  3. Min position size (`params.min_position_btc`)
+  4. Per-position cap (`params.max_position_pct * pool_equity`)
+  5. Directional headroom (`max_long_btc` / `max_short_btc`)
 
 Effects:
 
 - On success, IO type set to `Memo` (funds locked in order)
-- For market orders, Memo UTXO lookup is performed and stored
 - `request_ids[index]` is updated
+- Account state is synced before submission
+
+#### 6.1.1 Pre-flight market / risk checks
+
+Call these directly if you want to probe the relayer before deciding to submit:
+
+```rust
+order_wallet.validate_market_not_halted().await?;
+order_wallet
+    .validate_open_order(&PositionType::LONG, initial_margin, leverage)
+    .await?;
+```
 
 ### 6.2 Querying Orders
 
@@ -329,7 +355,17 @@ let order = order_wallet.query_trader_order(account_index).await?;
 println!("status: {:?}", order.order_status);
 ```
 
-Statuses include: `PENDING`, `FILLED`, `SETTLED`, `CANCELLED`.
+Statuses include: `PENDING`, `FILLED`, `SETTLED`, `CANCELLED`, `LIQUIDATE`.
+
+Enhanced and historical views:
+
+- `query_trader_order_v1(index)` – returns `TraderOrderV1` with `settle_limit`, `stop_loss`, `take_profit`, `funding_applied`
+- `query_lend_order_v1(index)` – returns `LendOrderV1` with unrealised profit and APR
+- `historical_trader_order(index) -> Vec<TraderOrder>`
+- `historical_lend_order(index) -> Vec<LendOrder>`
+- `order_funding_history(index) -> Vec<FundingHistoryEntry>`
+
+If the query fails and the underlying tx status is terminal-but-not-viable (not PENDING/FILLED/LIQUIDATE), `query_trader_order` auto-unlocks the account back to `Coin` via `unlock_failed_order` and returns an error with the reason.
 
 ### 6.3 Closing Positions
 
@@ -343,19 +379,57 @@ let close_id = order_wallet
 
 Requirements and effects:
 
-- The existing order must be `FILLED`
+- If the order is already `SETTLED` or `LIQUIDATE`, `close_trader_order` short-circuits to `unlock_trader_order` and just settles the account locally
+- Otherwise the current order must be `FILLED`
 - After settlement, account IO type becomes `Coin`
 - Balance is refreshed from the returned `available_margin`
 - UTXO details are updated to Coin state
 
-### 6.4 Canceling Pending Orders
+#### 6.3.1 Close with stop-loss / take-profit
+
+```rust
+let request_id = order_wallet
+    .close_trader_order_sltp(
+        account_index,
+        OrderType::LIMIT,
+        execution_price,   // 0.0 for MARKET
+        Some(stop_loss),   // or None
+        Some(take_profit), // or None
+    )
+    .await?;
+```
+
+- Requires the order to be `FILLED`
+- Same auto-unlock behavior as `close_trader_order` if the order is already `SETTLED`/`LIQUIDATE`
+
+### 6.4 Canceling Orders
 
 ```rust
 let cancel_id = order_wallet.cancel_trader_order(account_index).await?;
 ```
 
-- Only allowed when order is `PENDING`
-- After cancel, IO type becomes `Coin`; balance restored from `available_margin`
+- Allowed when the order is `PENDING` (LIMIT open) or has an outstanding settle limit (close LIMIT)
+- For pending LIMIT opens: on confirmed cancel, IO type becomes `Coin`; balance is unchanged (margin was never locked on the server)
+- For close-limit cancels: the close request is withdrawn; the position remains `FILLED`
+
+#### 6.4.1 Cancel stop-loss / take-profit
+
+```rust
+let request_id = order_wallet
+    .cancel_trader_order_sltp(account_index, cancel_sl, cancel_tp)
+    .await?;
+```
+
+- Requires the order to be `FILLED`
+- Must have at least one of SL or TP attached; use the boolean flags to select which to cancel
+
+#### 6.4.2 Manual unlock helpers
+
+When using `--no-wait` style flows or recovering from a failed submission, these helpers reconcile local state with the chain:
+
+- `unlock_trader_order(index) -> Result<(OrderStatus, String), String>` – verify a closed/liquidated trader order has settled on chain and return the account to `Coin`
+- `unlock_lend_order(index) -> Result<(OrderStatus, String), String>` – same for a settled lend order
+- `unlock_failed_order(index) -> Result<(), String>` – best-effort local recovery when a submission failed before the account could transition to `Memo` cleanly
 
 ### 6.5 Order Status Lifecycle
 
@@ -394,7 +468,8 @@ println!("status: {:?}, amount: {}", lend.order_status, lend.new_lend_state_amou
 let close_id = order_wallet.close_lend_order(account_index).await?;
 ```
 
-- Requires current status `FILLED`
+- If the lend order is already `SETTLED`, `close_lend_order` short-circuits to `unlock_lend_order`
+- Otherwise requires current status `FILLED`
 - On success: status `SETTLED`, IO type becomes `Coin`, balance set to `new_lend_state_amount`
 
 ---
@@ -502,58 +577,58 @@ for w in list { println!("{} {}", w.wallet_id, w.created_at); }
 
 ## 10 • Environment Configuration
 
-Required or useful variables (local defaults shown):
+Most endpoint defaults are selected by `NETWORK_TYPE` — the columns below show the **mainnet** and **testnet** defaults picked by `src/config.rs`. Override any value by exporting the variable explicitly.
 
-| Variable                     | Default                                                       | Description                                                  |
-| ---------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------ |
-| `RUST_LOG`                   | `info,debug`                                                  | Logging level configuration                                  |
-| `RUST_BACKTRACE`             | `full`                                                        | Enable Rust backtrace for debugging                          |
-| `CHAIN_ID`                   | `nyks`                                                        | Target blockchain network ID                                 |
-| `NYKS_RPC_BASE_URL`          | `http://0.0.0.0:26657`                                        | Nyks chain RPC endpoint                                      |
-| `NYKS_LCD_BASE_URL`          | `http://0.0.0.0:1317`                                         | Nyks chain LCD endpoint                                      |
-| `FAUCET_BASE_URL`            | `http://0.0.0.0:6969`                                         | Faucet for test tokens                                       |
-| `RELAYER_API_RPC_SERVER_URL` | `http://0.0.0.0:8088/api`                                     | Relayer public API endpoint (required for order-wallet)      |
-| `PUBLIC_API_RPC_SERVER_URL`  | `http://0.0.0.0:8088/api`                                     | Public API endpoint (can be same as relayer)                 |
-| `RELAYER_RPC_SERVER_URL`     | `http://0.0.0.0:3032`                                         | Relayer client API endpoint (order-wallet)                   |
-| `ZKOS_SERVER_URL`            | `http://0.0.0.0:3030`                                         | ZkOS server endpoint (order-wallet and relayer-init bin)     |
-| `RELAYER_PROGRAM_JSON_PATH`  | `./relayerprogram.json`                                       | Path to relayer program JSON                                 |
-| `NYKS_WALLET_PASSPHRASE`     | `test1_password`                                              | Wallet passphrase; leave empty to use interactive prompt     |
-| `WALLET_ID`                  |                                                               | Optional wallet ID (defaults to Twilight address if not set) |
-| `DATABASE_URL_POSTGRESQL`    | `postgresql://username:password@localhost:5432/database_name` | PostgreSQL connection string                                 |
-| `DATABASE_URL_SQLITE`        | `./wallet_data.db`                                            | SQLite database file path                                    |
-| `VALIDATOR_WALLET_PATH`      | `validator-self.mnemonic`                                     | Validator mnemonic file (validator-wallet feature)           |
+| Variable                     | Default (mainnet)                       | Default (testnet)                      | Description                                                  |
+| ---------------------------- | --------------------------------------- | -------------------------------------- | ------------------------------------------------------------ |
+| `NETWORK_TYPE`               | `mainnet`                               | `mainnet`                              | `mainnet` or `testnet`; selects defaults for other endpoints |
+| `BTC_NETWORK_TYPE`           | `mainnet`                               | `mainnet`                              | `mainnet` or `testnet` for BTC endpoints; nyks chain only supports BTC mainnet — keep this as `mainnet` even when `NETWORK_TYPE=testnet` |
+| `CHAIN_ID`                   | `nyks`                                  | `nyks`                                 | Target blockchain chain ID                                   |
+| `RUST_LOG`                   | –                                       | –                                      | Logging level (e.g. `info`, `debug`)                         |
+| `RUST_BACKTRACE`             | –                                       | –                                      | Enable Rust backtrace (`1` or `full`)                        |
+| `NYKS_RPC_BASE_URL`          | `https://rpc.twilight.org`              | `https://rpc.twilight.rest`            | Nyks chain Tendermint RPC endpoint                           |
+| `NYKS_LCD_BASE_URL`          | `https://lcd.twilight.org`              | `https://lcd.twilight.rest`            | Nyks chain LCD REST endpoint                                 |
+| `FAUCET_BASE_URL`            | *(empty)*                               | `https://faucet-rpc.twilight.rest`     | Faucet for test tokens (testnet only)                        |
+| `RELAYER_API_RPC_SERVER_URL` | `https://api.ephemeral.fi/api`          | `https://relayer.twilight.rest/api`    | Relayer public JSON-RPC API (required for order-wallet)      |
+| `ZKOS_SERVER_URL`            | `https://zkserver.twilight.org`         | `https://nykschain.twilight.rest/zkos` | ZkOS server endpoint                                         |
+| `TWILIGHT_INDEXER_URL`       | `https://indexer.twilight.org`          | `https://indexer.twilight.rest`        | Twilight indexer endpoint                                    |
+| `BTC_ESPLORA_PRIMARY_URL`    | `https://blockstream.info/api`          | `https://blockstream.info/testnet/api` | Primary Esplora API for BTC queries (driven by `BTC_NETWORK_TYPE`) |
+| `BTC_ESPLORA_FALLBACK_URL`   | `https://mempool.space/api`             | `https://mempool.space/testnet/api`    | Fallback Esplora API (driven by `BTC_NETWORK_TYPE`)          |
+| `RELAYER_PROGRAM_JSON_PATH`  | `./relayerprogram.json`                 | `./relayerprogram.json`                | Path to relayer program JSON                                 |
+| `VALIDATOR_WALLET_PATH`      | `validator.mnemonic`                    | `validator.mnemonic`                   | Validator mnemonic file (validator-wallet feature)           |
+| `NYKS_WALLET_PASSPHRASE`     | –                                       | –                                      | Wallet passphrase; leave unset to use interactive prompt     |
+| `WALLET_ID`                  | –                                       | –                                      | Optional wallet ID (defaults to Twilight address if not set) |
+| `DATABASE_URL_SQLITE`        | `./wallet_data.db`                      | `./wallet_data.db`                     | SQLite database file path (feature `sqlite`)                 |
+| `DATABASE_URL_POSTGRESQL`    | –                                       | –                                      | PostgreSQL connection string (feature `postgresql`)          |
 
 Example local development setup:
 
 ```bash
 export RUST_LOG="info,debug"
 export RUST_BACKTRACE=full
+export NETWORK_TYPE=testnet                 # picks *.twilight.rest endpoints
+export BTC_NETWORK_TYPE=mainnet              # nyks chain only supports BTC mainnet
 export CHAIN_ID=nyks
-export NYKS_RPC_BASE_URL="http://0.0.0.0:26657"
-export NYKS_LCD_BASE_URL="http://0.0.0.0:1317"
-export FAUCET_BASE_URL="http://0.0.0.0:6969"
-export RELAYER_API_RPC_SERVER_URL="http://0.0.0.0:8088/api"
-export PUBLIC_API_RPC_SERVER_URL="http://0.0.0.0:8088/api"
-export RELAYER_RPC_SERVER_URL="http://0.0.0.0:3032"
-export ZKOS_SERVER_URL="http://0.0.0.0:3030"
+# Override individual endpoints only if pointing to a local full-node:
+# export NYKS_RPC_BASE_URL="http://0.0.0.0:26657"
+# export NYKS_LCD_BASE_URL="http://0.0.0.0:1317"
+# export FAUCET_BASE_URL="http://0.0.0.0:6969"
+# export RELAYER_API_RPC_SERVER_URL="http://0.0.0.0:8088/api"
+# export ZKOS_SERVER_URL="http://0.0.0.0:3030"
 export RELAYER_PROGRAM_JSON_PATH="./relayerprogram.json"
 export NYKS_WALLET_PASSPHRASE="test1_password"
 export DATABASE_URL_SQLITE="./wallet_data.db"
 ```
 
-Example production setup:
+Example production (mainnet) setup — defaults are already correct, typically only secrets and program path need to be set:
 
 ```bash
 export RUST_LOG=info
+export NETWORK_TYPE=mainnet
+export BTC_NETWORK_TYPE=mainnet
 export CHAIN_ID=nyks
-export NYKS_RPC_BASE_URL="https://rpc.twilight.rest"
-export NYKS_LCD_BASE_URL="https://lcd.twilight.rest"
-export FAUCET_BASE_URL="https://faucet-rpc.twilight.rest"
-export RELAYER_API_RPC_SERVER_URL="https://relayer.twilight.rest/api"
-export PUBLIC_API_RPC_SERVER_URL="https://relayer.twilight.rest/api"
-export RELAYER_RPC_SERVER_URL="https://relayer.twilight.rest/clientapi"
-export ZKOS_SERVER_URL="https://zkos.twilight.rest"
 export RELAYER_PROGRAM_JSON_PATH="/path/to/relayerprogram.json"
+export NYKS_WALLET_PASSPHRASE="<secure-passphrase>"
 ```
 
 ---
@@ -563,11 +638,12 @@ export RELAYER_PROGRAM_JSON_PATH="/path/to/relayerprogram.json"
 Common errors and resolutions:
 
 - "Insufficient balance" → top up wallet or reduce size
-- "Account is not on chain or not a coin account" → wait for `funding_to_trading` confirmation
-- "Leverage must be greater than 0 and less than 50" → fix parameter
-- "Entry price must be greater than 0" → fix parameter
-- "Order is not filled" (on close) → wait for fill or cancel
-- "Order is not pending" (on cancel) → only pending orders can be cancelled
+- "Account does not exist on chain or has no balance" / "Account is locked, io type: …" → wait for `funding_to_trading` confirmation, or the account is currently in `Memo` state
+- "Leverage must be greater than 0" → fix parameter (upper bound comes from risk-engine validation, surfaced as "Leverage X exceeds maximum allowed Y")
+- "Market is halted: …" / "Market is in close-only mode: …" → relayer market guard; retry when market resumes
+- "Position size … is below minimum …" / "… exceeds per-position cap …" / "… exceeds max available long/short capacity …" → risk-engine rejection from `validate_open_order`
+- "Order is not filled, status: …" (on close) → wait for fill or cancel; if status is `SETTLED`/`LIQUIDATE`, `close_trader_order` will auto-unlock
+- "Order is not pending or close limit, status: …" (on cancel) → only PENDING opens or outstanding close-limits can be cancelled
 - UTXO/TxHash fetch failures → network hiccups; automatic retries are included
 
 Robust retry example:

--- a/QuickStart.md
+++ b/QuickStart.md
@@ -1,6 +1,6 @@
 # Quick Start – Nyks Wallet SDK
 
-This guide gets you from **zero to a funded test wallet in ~60 seconds**. For a deeper dive, see `README.md` and `Deployment.md`.
+This guide gets you from **zero to a funded test wallet in ~60 seconds**. For a deeper dive, see [`README.md`](README.md) and [`DEPLOYMENT.md`](DEPLOYMENT.md).
 
 ---
 
@@ -27,40 +27,58 @@ $ cd nyks-wallet
 $ cargo build --release
 ```
 
-This produces the library **and** the sample binary `relayer_init` in `target/release/`.
+This produces the library **and** two binaries in `target/release/`: `relayer-init` (bootstrap) and `relayer-cli` (interactive CLI).
 
 ---
 
 ## 3 • Configure endpoints
 
-Nyks Wallet talks to the public Twilight test-net. Endpoints are read from environment variables and will **panic if missing**.
+Endpoints come from environment variables; every variable has a built-in default chosen by `NETWORK_TYPE` (mainnet vs testnet), so nothing is required — override only when you want to point at a local full-node.
 
 ```bash
-cat <<'EOF' > .env.blbal
-NYKS_LCD_BASE_URL=https://lcd.twilight.rest
-NYKS_RPC_BASE_URL=https://rpc.twilight.rest
-FAUCET_BASE_URL=https://faucet-rpc.twilight.rest
-ZKOS_SERVER_URL=https://nykschain.twilight.rest/zkos
+cat <<'EOF' > .env
+# Select the network. Mainnet is the default if unset.
+NETWORK_TYPE=testnet
+# nyks chain only supports BTC mainnet — keep this as mainnet even on testnet.
+BTC_NETWORK_TYPE=mainnet
+CHAIN_ID=nyks
+
+# The following testnet endpoints are the built-in defaults for NETWORK_TYPE=testnet.
+# Only set them explicitly if you need to override.
+# NYKS_LCD_BASE_URL=https://lcd.twilight.rest
+# NYKS_RPC_BASE_URL=https://rpc.twilight.rest
+# FAUCET_BASE_URL=https://faucet-rpc.twilight.rest
+# ZKOS_SERVER_URL=https://nykschain.twilight.rest/zkos
+# RELAYER_API_RPC_SERVER_URL=https://relayer.twilight.rest/api
+
 RUST_LOG=info
 EOF
 
 # load them in your current shell
-source .env
+set -a; source .env; set +a
 ```
+
+> See [`.env.example`](.env.example) for the full list and [README.md §7](README.md#7--environment-variables) for the mainnet/testnet defaults.
 
 ---
 
 ## 4 • Run the one-liner demo
 
 ```bash
-# generates a fresh wallet, funds it, deploys relayer contract
-$ cargo run --bin relayer_init
+# generates a fresh wallet, funds it on testnet, writes relayer_deployer.json
+$ cargo run --bin relayer-init
 ```
 
 On success you will see `relayer_deployer.json` in the working directory plus log output similar to:
 
 ```
 Successfully wrote relayer data to relayer_deployer.json
+```
+
+Try the interactive CLI next:
+
+```bash
+$ cargo run --bin relayer-cli -- --help
 ```
 
 ---
@@ -83,7 +101,7 @@ use nyks_wallet::wallet::{Wallet, get_test_tokens};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // 1️⃣ create a random Cosmos+BTC wallet
-    let mut wallet = Wallet::create_new_with_random_btc_address()?;
+    let mut wallet = Wallet::create_new_with_random_btc_address().await?;
 
     // 2️⃣ request test-net tokens (10 000 nyks & 50 000 sats)
     get_test_tokens(&mut wallet).await?;
@@ -104,8 +122,10 @@ cargo run -q
 
 ## 6 • Next steps
 
-• Explore the full API surface in [`README.md`](README.md).  
-• Check the [Deployment guide](DEPLOYMENT.md) for Docker usage and advanced relayer setup.  
+• Explore the full API surface in [`README.md`](README.md).
+• Read the [OrderWallet guide](OrderWallet.md) for trading and lending.
+• See the [`relayer-cli` reference](docs/relayer-cli.md) for the interactive CLI.
+• Check the [Deployment guide](DEPLOYMENT.md) for Docker usage and advanced relayer setup.
 • Join the discussion on Discord: https://discord.gg/twilight-protocol
 
 Happy building! 🚀

--- a/README.md
+++ b/README.md
@@ -75,26 +75,40 @@ All network calls run on **Tokio + Reqwest**, all crypto is handled via **k256**
 
 ### 4.1 Wallet lifecycle
 
-- `Wallet::new(None)` – generate a random Cosmos key-pair _and_ deterministic testnet BTC address.
-- `Wallet::from_mnemonic(..)` / `Wallet::from_private_key(..)` – import existing credentials.
-- `Wallet::import_from_json(..)` / `export_to_json(..)` – round-trip safe serialization for long-term storage.
+- `Wallet::new(chain_config: Option<WalletEndPointConfig>)` – generate a random Cosmos key-pair along with a BIP-39 BTC wallet; prints the 24-word mnemonic once to the TTY.
+- `Wallet::create_new_with_random_btc_address()` – async variant that does not print the mnemonic (used in automated flows).
+- `Wallet::from_mnemonic(mnemonic, chain_config)` – import an existing 24-word mnemonic.
+- `Wallet::from_private_key(private_key, btc_address, chain_config)` – import using a raw secp256k1 hex private key (no BTC wallet, just an address).
+- `Wallet::from_mnemonic_file(path)` – read mnemonic from a file (used by the validator wallet).
+- `Wallet::import_from_json(path)` / `Wallet::export_to_json(path)` – round-trip safe serialization for long-term storage.
 
-### 4.2 Balance management
+> The BTC network (`mainnet` vs `testnet`) used to derive the BIP-86 Taproot address is controlled by `BTC_NETWORK_TYPE` — default `mainnet`. The nyks chain only supports BTC mainnet, so keep `BTC_NETWORK_TYPE=mainnet` even on nyks testnet.
 
-- `wallet::check_balance(addr)` – one-shot REST query.
+### 4.2 Balance & account info
+
+- `wallet::check_balance(addr, lcd_endpoint)` – one-shot REST query against the LCD endpoint.
 - `Wallet::update_balance()` – refreshes the embedded `balance_nyks` & `balance_sats` fields.
+- `Wallet::account_info()` / `Wallet::update_account_info()` – fetches the Cosmos auth account (sequence + account number).
 
-### 4.3 Faucet helpers
+### 4.3 Faucet helpers (testnet only)
 
-- `faucet::get_nyks(addr)` – requests **10 000 nyks**.
-- `faucet::mint_sats(addr)` – mints **50 000 test satoshis**.
-- `faucet::mint_sats_5btc(addr)` – special 5 BTC mint used by relayer wallets.
+- `faucet::get_nyks(addr, faucet_endpoint)` – requests **10 000 nyks**.
+- `faucet::mint_sats(addr, faucet_endpoint)` – mints **50 000 test satoshis**.
+- `faucet::mint_sats_5btc(addr, faucet_endpoint)` – special 5 BTC mint used by relayer wallets.
+- `wallet::get_test_tokens(&mut wallet)` – one-shot helper that requests nyks, registers the BTC address, and mints sats. Errors on mainnet (`NETWORK_TYPE=mainnet`).
 
-### 4.4 BTC deposit registration & trading
+### 4.4 BTC deposit & withdrawal
 
-- `faucet::sign_and_send_reg_deposit_tx(..)` – signs a `MsgRegisterBtcDepositAddress` and broadcasts it.
-- `nyks_fn::create_funiding_to_trading_tx_msg(..)` – crafts a **mint/burn** trading message.
-- `nyks_fn::send_tx(msg)` – generic helper that signs & synchronously broadcasts any protobuf `Any`.
+- `Wallet::register_btc_deposit(..)` – signs and broadcasts `MsgRegisterBtcDepositAddress`.
+- `Wallet::withdraw_btc(..)` – signs and broadcasts `MsgWithdrawBtcRequest`.
+- `Wallet::fetch_deposit_status()` / `fetch_deposit_details()` – query current deposit state from the indexer.
+- `Wallet::fetch_withdrawal_status(..)` – query withdrawal progress by ID.
+- `Wallet::fetch_btc_reserves()` / `fetch_btc_proposed_reserve()` – read live BTC reserve state.
+- `Wallet::fetch_registered_btc_by_address(..)` – verify whether a given address is registered on-chain.
+- `Wallet::fetch_account_from_indexer()` – full indexer view of the account (deposits, withdrawals, balances).
+- `Wallet::send_tokens(to_address, amount, denom)` – send `nyks` or `sats` to another Twilight address.
+- `faucet::sign_and_send_reg_deposit_tx(..)` – lower-level primitive that signs a `MsgRegisterBtcDepositAddress`.
+- `nyks_fn::create_funiding_to_trading_tx_msg(..)` – crafts a mint/burn trading message (note: the typo `funiding` is intentional in the current API surface).
 
 ### 4.5 ZkOS / QuisQuis accounts
 
@@ -154,35 +168,45 @@ All network calls run on **Tokio + Reqwest**, all crypto is handled via **k256**
 
 ## 7 • Environment variables
 
-| Variable                     | Default                   | Description                                           |
-| ---------------------------- | ------------------------- | ----------------------------------------------------- |
-| `NYKS_LCD_BASE_URL`          | `http://0.0.0.0:1317`     | Cosmos SDK LCD REST endpoint                          |
-| `NYKS_RPC_BASE_URL`          | `http://0.0.0.0:26657`    | Tendermint RPC endpoint                               |
-| `FAUCET_BASE_URL`            | `http://0.0.0.0:6969`     | Faucet & mint endpoints                               |
-| `ZKOS_SERVER_URL`            | `http://0.0.0.0:3030`     | ZkOS / QuisQuis JSON-RPC server                       |
-| `RELAYER_API_RPC_SERVER_URL` | `http://0.0.0.0:8088/api` | Relayer public JSON-RPC API (OrderWallet)             |
-| `PUBLIC_API_RPC_SERVER_URL`  | `http://0.0.0.0:8088/api` | Public price-feed / order-book API                    |
-| `RELAYER_RPC_SERVER_URL`     | `http://0.0.0.0:3032`     | Internal relayer client RPC                           |
-| `RELAYER_PROGRAM_JSON_PATH`  | `./relayerprogram.json`   | Path to relayer program ABI/bytecode                  |
-| `CHAIN_ID`                   | `nyks`                    | Chain identifier used in signed msgs                  |
-| `RUST_LOG`                   | `info`                    | Log level (`info`, `debug`, `trace`, …)               |
-| `RUST_BACKTRACE`             | `full`                    | Enable Rust backtraces for debugging                  |
-| `NYKS_WALLET_PASSPHRASE`     | –                         | Passphrase used to encrypt wallet seed                |
-| `WALLET_ID`                  | –                         | Override default wallet ID when using DB              |
-| `VALIDATOR_WALLET_PATH`      | `validator-self.mnemonic` | Path to validator mnemonic (validator-wallet)         |
-| `DATABASE_URL_SQLITE`        | `./wallet_data.db`        | SQLite file used when feature = `sqlite`              |
-| `DATABASE_URL_POSTGRESQL`    | –                         | PostgreSQL connection string (feature = `postgresql`) |
+Endpoint defaults are selected by `NETWORK_TYPE` (and `BTC_NETWORK_TYPE` for BTC-specific ones). Override any variable explicitly to point at a local full-node.
 
-Set them before running to point the SDK at a local full-node.
+| Variable                     | Default (mainnet)                       | Default (testnet)                      | Description                                      |
+| ---------------------------- | --------------------------------------- | -------------------------------------- | ------------------------------------------------ |
+| `NETWORK_TYPE`               | `mainnet`                               | `mainnet`                              | Selects endpoint defaults (`mainnet` / `testnet`) |
+| `BTC_NETWORK_TYPE`           | `mainnet`                               | `mainnet`                              | BTC network for Esplora endpoints (nyks only supports BTC mainnet) |
+| `CHAIN_ID`                   | `nyks`                                  | `nyks`                                 | Chain identifier used in signed msgs             |
+| `NYKS_LCD_BASE_URL`          | `https://lcd.twilight.org`              | `https://lcd.twilight.rest`            | Cosmos SDK LCD REST endpoint                     |
+| `NYKS_RPC_BASE_URL`          | `https://rpc.twilight.org`              | `https://rpc.twilight.rest`            | Tendermint RPC endpoint                          |
+| `FAUCET_BASE_URL`            | *(empty)*                               | `https://faucet-rpc.twilight.rest`     | Faucet & mint endpoints (testnet only)           |
+| `ZKOS_SERVER_URL`            | `https://zkserver.twilight.org`         | `https://nykschain.twilight.rest/zkos` | ZkOS / QuisQuis JSON-RPC server                  |
+| `RELAYER_API_RPC_SERVER_URL` | `https://api.ephemeral.fi/api`          | `https://relayer.twilight.rest/api`    | Relayer public JSON-RPC API (OrderWallet)        |
+| `TWILIGHT_INDEXER_URL`       | `https://indexer.twilight.org`          | `https://indexer.twilight.rest`        | Twilight indexer endpoint                        |
+| `BTC_ESPLORA_PRIMARY_URL`    | `https://blockstream.info/api`          | `https://blockstream.info/testnet/api` | Primary Esplora API (driven by `BTC_NETWORK_TYPE`) |
+| `BTC_ESPLORA_FALLBACK_URL`   | `https://mempool.space/api`             | `https://mempool.space/testnet/api`    | Fallback Esplora API (driven by `BTC_NETWORK_TYPE`) |
+| `RELAYER_PROGRAM_JSON_PATH`  | `./relayerprogram.json`                 | `./relayerprogram.json`                | Path to relayer program ABI/bytecode             |
+| `VALIDATOR_WALLET_PATH`      | `validator.mnemonic`                    | `validator.mnemonic`                   | Path to validator mnemonic (validator-wallet feature); `.env.example` overrides to `validator-self.mnemonic` |
+| `RUST_LOG`                   | –                                       | –                                      | Log level (`info`, `debug`, `trace`, …)          |
+| `RUST_BACKTRACE`             | –                                       | –                                      | Enable Rust backtraces for debugging             |
+| `NYKS_WALLET_PASSPHRASE`     | –                                       | –                                      | Passphrase used to encrypt wallet seed           |
+| `WALLET_ID`                  | –                                       | –                                      | Override default wallet ID when using DB         |
+| `DATABASE_URL_SQLITE`        | `./wallet_data.db`                      | `./wallet_data.db`                     | SQLite file used when feature = `sqlite`         |
+| `DATABASE_URL_POSTGRESQL`    | –                                       | –                                      | PostgreSQL connection string (feature = `postgresql`) |
 
 ---
 
 ## 8 • Getting started in your own project
 
-```bash
+```toml
 # Cargo.toml
 [dependencies]
-nyks-wallet = { path = "../nyks-wallet" }    # or github = "twilight-project/nyks-wallet"
+nyks-wallet = { git = "https://github.com/twilight-project/nyks-wallet", tag = "v0.1.2" }
+# or: nyks-wallet = { path = "../nyks-wallet" }
+```
+
+Default features enable `sqlite` + `order-wallet`. Disable defaults and pick your own set if you don't need the DB:
+
+```toml
+nyks-wallet = { git = "...", default-features = false, features = ["order-wallet"] }
 ```
 
 ```rust
@@ -190,16 +214,29 @@ use nyks_wallet::wallet::{Wallet, get_test_tokens};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Import an existing key (mnemonic, hex or JSON)
-    let mut wallet = Wallet::from_mnemonic("your twelve words …")?;
+    // Import an existing 24-word mnemonic (chain_config=None → defaults from NETWORK_TYPE)
+    let mut wallet = Wallet::from_mnemonic("your twenty-four words …", None)?;
 
-    // Fund it on test-net
+    // Fund it on test-net (requires NETWORK_TYPE=testnet; errors on mainnet)
     get_test_tokens(&mut wallet).await?;
 
     println!("Twilight address: {}", wallet.twilightaddress);
     println!("Balance: {} nyks, {} sats", wallet.balance_nyks, wallet.balance_sats);
     Ok(())
 }
+```
+
+### 8.1 Binaries shipped with the crate
+
+The crate also builds two CLIs (both require the `order-wallet` feature, which is on by default):
+
+- **`relayer-init`** – one-shot bootstrap that creates a wallet, funds it on testnet, and writes `relayer_deployer.json`. See [DEPLOYMENT.md](DEPLOYMENT.md).
+- **`relayer-cli`** – interactive REPL + subcommand CLI for wallets, ZkOS accounts, orders, market data, portfolio, and self-update. See [`docs/relayer-cli.md`](docs/relayer-cli.md).
+
+```bash
+cargo build --release           # builds lib + both binaries with default features
+cargo run --bin relayer-init    # run the bootstrap
+cargo run --bin relayer-cli -- --help
 ```
 
 ---

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,15 @@
 fn main() {
+    // Expose build date as BUILD_DATE env var for compile-time version string
+    let output = std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%d"])
+        .output()
+        .expect("failed to run date command");
+    let date = String::from_utf8(output.stdout)
+        .expect("invalid utf8 from date")
+        .trim()
+        .to_string();
+    println!("cargo:rustc-env=BUILD_DATE={date}");
+
     let out_dir = std::env::var("OUT_DIR").unwrap();
     println!("cargo:warning=Writing to OUT_DIR = {}", out_dir);
     prost_build::compile_protos(

--- a/docs/agent-skill-relayer-cli.md
+++ b/docs/agent-skill-relayer-cli.md
@@ -2,6 +2,23 @@
 
 A complete guide for AI agents and developers to build, configure, and operate the Twilight `relayer-cli`. This document is self-contained — read it to go from zero to executing trades.
 
+## Contents
+
+1. [Quick Start (pre-built binary)](#1-quick-start-pre-built-binary) — install the released binary in one command
+2. [Build from Source](#2-build-from-source) — Rust/protoc prerequisites, SQLite vs PostgreSQL
+3. [Configure](#3-configure) — env vars, endpoints, credential resolution, DB
+4. [Global CLI pattern](#4-global-cli-pattern) — `--json`, REPL, amount-units convention
+5. [Complete Workflow: Testnet](#5-complete-workflow-testnet) — create → faucet → trade → withdraw
+6. [Complete Workflow: Mainnet (BTC onboarding)](#6-complete-workflow-mainnet-btc-onboarding) — register/deposit/withdraw, manual flow for no-mnemonic wallets
+7. [Account State Model](#7-account-state-model) — ZkAccount fields, `Coin`/`Memo`/`State` semantics
+8. [Order Lifecycle](#8-order-lifecycle) — trade/lend flows, close-trade rules, status reference, numeric limits, preconditions
+9. [Command Quick Reference](#9-command-quick-reference) — every command in one place, grouped by domain
+10. [Multiple Orders via Split](#10-multiple-orders-via-split) — parallel orders from one funded account
+11. [Critical Rules](#11-critical-rules) — address reuse, reserve timing, network restrictions
+12. [Error Recovery](#12-error-recovery) — symptom → resolution table
+13. [JSON Output](#13-json-output) — `--json` shape by command category
+14. [Getting Unstuck](#14-getting-unstuck) — inline `help` / `--help` pointers
+
 ---
 
 ## 1. Quick Start (pre-built binary)
@@ -21,6 +38,8 @@ This auto-detects your platform, downloads the latest release, and installs `rel
 ```powershell
 irm https://raw.githubusercontent.com/twilight-project/nyks-wallet/main/install.ps1 | iex
 ```
+
+> **Note:** The pre-built binary is compiled with the **default feature set (SQLite backend)**. If you need the PostgreSQL backend, build from source — see [Section 2](#2-build-from-source).
 
 ### Verify
 
@@ -73,39 +92,69 @@ docker run -e RUST_LOG=info -e NETWORK_TYPE=testnet relayer-cli <command>
 
 ## 3. Configure
 
-### Minimal .env for mainnet
+A `.env` file in the working directory is loaded automatically. All defaults are built into the binary — you typically don't need to set anything beyond `RUST_LOG` and (for testnet) `NETWORK_TYPE`.
+
+### Minimal .env
 
 ```bash
+# Mainnet
 RUST_LOG=info
-```
 
-That's it. All defaults (`NETWORK_TYPE=mainnet`, endpoints, database path, relayer program path) are built into the binary. No other env vars are required.
-
-### Minimal .env for testnet
-
-```bash
+# Testnet
 RUST_LOG=info
 NETWORK_TYPE=testnet
 ```
 
-All testnet endpoints auto-resolve from `NETWORK_TYPE=testnet`. Override only if needed (e.g., local development).
-
-### Key env vars
+### Core variables
 
 | Variable | Purpose | Default |
 |---|---|---|
-| `NETWORK_TYPE` | `mainnet` or `testnet` — controls endpoints and BIP-44 derivation | `mainnet` |
-| `BTC_NETWORK_TYPE` | Bitcoin network for BTC keys/balance — falls back to hardcoded `mainnet` | `mainnet` |
-| `NYKS_WALLET_ID` | Default wallet ID when `--wallet-id` is omitted | — |
-| `NYKS_WALLET_PASSPHRASE` | Default password when `--password` is omitted | — |
-| `DATABASE_URL_SQLITE` | SQLite database path | `./wallet_data.db` |
+| `RUST_LOG` | Logging level (`info`, `debug`, `trace`) | — |
+| `RUST_BACKTRACE` | Rust backtraces (`1` or `full`) | — |
+| `CHAIN_ID` | Blockchain network identifier | `nyks` |
+| `NETWORK_TYPE` | `mainnet` or `testnet` — controls nyks chain endpoints and BIP-44 derivation | `mainnet` |
+| `BTC_NETWORK_TYPE` | Bitcoin network for BTC key derivation. See note below — leave as `mainnet` for normal use | `mainnet` |
 
-### Wallet credential resolution order
+> **Important — `BTC_NETWORK_TYPE` does NOT follow `NETWORK_TYPE`.** The Nyks chain only supports **BTC mainnet**, even when running against nyks testnet. All deposit/withdraw flows (`register-btc`, `deposit-btc`, `withdraw-btc`, reserves) operate on BTC mainnet regardless of `NETWORK_TYPE`. Keep `BTC_NETWORK_TYPE=mainnet` (the default) for both nyks mainnet and nyks testnet. Only set `BTC_NETWORK_TYPE=testnet` when **locally testing the `bitcoin-wallet` subcommands** (`balance`, `transfer`, `receive`) against the Bitcoin testnet — never combine it with the register/deposit/withdraw flows.
 
-1. `--wallet-id` / `--password` CLI flags
-2. Session cache (`wallet unlock`)
-3. `NYKS_WALLET_ID` / `NYKS_WALLET_PASSPHRASE` env vars
-4. Interactive prompt (for `wallet unlock` only)
+### Chain endpoints (auto-resolved from `NETWORK_TYPE`)
+
+| Variable | Default (mainnet) | Default (testnet) |
+|---|---|---|
+| `NYKS_RPC_BASE_URL` | `https://rpc.twilight.org` | `https://rpc.twilight.rest` |
+| `NYKS_LCD_BASE_URL` | `https://lcd.twilight.org` | `https://lcd.twilight.rest` |
+| `FAUCET_BASE_URL` | disabled | `https://faucet-rpc.twilight.rest` |
+| `TWILIGHT_INDEXER_URL` | `https://indexer.twilight.org` | `https://indexer.twilight.rest` |
+| `BTC_ESPLORA_PRIMARY_URL` | `https://blockstream.info/api` | `https://blockstream.info/testnet/api` |
+| `BTC_ESPLORA_FALLBACK_URL` | `https://mempool.space/api` | `https://mempool.space/testnet/api` |
+
+### Order-wallet endpoints (required for trading/lending/ZkOS)
+
+| Variable | Default (mainnet) | Default (testnet) |
+|---|---|---|
+| `RELAYER_API_RPC_SERVER_URL` | `https://api.ephemeral.fi/api` | `https://relayer.twilight.rest/api` |
+| `ZKOS_SERVER_URL` | `https://zkserver.twilight.org` | `https://nykschain.twilight.rest/zkos` |
+| `RELAYER_PROGRAM_JSON_PATH` | `./relayerprogram.json` | `./relayerprogram.json` |
+
+### Wallet credentials
+
+| Variable | Purpose |
+|---|---|
+| `NYKS_WALLET_ID` | Default wallet ID when `--wallet-id` is omitted |
+| `NYKS_WALLET_PASSPHRASE` | Default password when `--password` is omitted |
+
+**Resolution order** (for both wallet-id and password):
+1. CLI flag (`--wallet-id`, `--password`)
+2. Session cache (set via `wallet unlock`)
+3. Env var (`NYKS_WALLET_ID`, `NYKS_WALLET_PASSPHRASE`)
+4. Interactive prompt (only for `wallet unlock`; other commands error out)
+
+### Database
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `DATABASE_URL_SQLITE` | SQLite file path (default feature) | `./wallet_data.db` |
+| `DATABASE_URL_POSTGRESQL` | PostgreSQL connection string (requires `--features postgresql` build) | — |
 
 ---
 
@@ -116,6 +165,24 @@ relayer-cli [--json] <command-group> <subcommand> [flags]
 ```
 
 `--json` outputs JSON instead of formatted tables. Useful for scripting/parsing.
+
+### Amount units (shared across commands that take a BTC amount)
+
+Commands that accept a BTC amount (`zkaccount fund`, `wallet deposit-btc`, `bitcoin-wallet transfer`) take **exactly one** of these three flags:
+
+| Flag | Unit | Example |
+|---|---|---|
+| `--amount <sats>` | satoshis (integer) | `--amount 50000` |
+| `--amount-mbtc <mBTC>` | milli-BTC (float) | `--amount-mbtc 0.5` |
+| `--amount-btc <BTC>` | BTC (float) | `--amount-btc 0.0005` |
+
+Conversion: **1 BTC = 100,000 mBTC = 100,000,000 sats**.
+
+`zkaccount split` uses the plural-list variants: `--balances "1000,2000,3000"` (sats), `--balances-mbtc`, `--balances-btc`.
+
+**Display units (separate from input):**
+- `bitcoin-wallet balance` accepts `--btc` or `--mbtc` flags to display the balance in that unit (default: sats).
+- `portfolio balances` accepts `--unit sats|mbtc|btc`.
 
 ### REPL (Interactive Mode)
 
@@ -209,22 +276,58 @@ relayer-cli wallet withdraw-btc --reserve-id 1 --amount 50000
 relayer-cli wallet withdraw-status
 ```
 
+### Manual BTC deposit (no mnemonic, e.g. hardware wallet / external custody)
+
+If you don't want the CLI to hold Bitcoin signing keys, skip `wallet import` and instead set an external BTC address you control. The CLI will **not** auto-send — it only records the deposit intent and shows you the reserve address to pay from your external wallet.
+
+```bash
+# 1. Create wallet (no mnemonic, no BTC signing keys)
+relayer-cli wallet create --wallet-id main --password <pwd>
+
+# 2. Point the wallet at a BTC address you control elsewhere
+relayer-cli wallet update-btc-address --btc-address bc1q<your_external_address>
+
+# 3. Register + record a deposit intent. The CLI prints the reserve address to pay.
+relayer-cli wallet register-btc --amount 50000
+
+# 4. Send 50,000 sats from your external wallet to that reserve address
+#    IMPORTANT: MUST come from bc1q<your_external_address> — other senders are not credited.
+
+# 5. Wait for Bitcoin confirmation (~10 min) + validator confirmation (~1h+)
+relayer-cli wallet deposit-status
+
+# 6. Balance appears on Twilight — proceed to trading as in step 7 above
+relayer-cli wallet balance
+```
+
+For subsequent deposits after registration, use `wallet deposit-btc` (same pattern — prints the reserve address, you send manually).
+
 ---
 
 ## 7. Account State Model
 
-Each ZkOS account has three key fields:
+A **ZkAccount** is a privacy-preserving trading account on the ZkOS layer. Each account holds a balance, a cryptographic commitment (QuisQuis account), and state metadata.
 
-| Field | Values | Meaning |
+### Full account fields (as shown in `wallet accounts` output and returned by queries)
+
+| Field | Values / Type | Meaning |
 |---|---|---|
-| `io_type` | `Coin`, `Memo`, `State` | Account state on ZkOS |
-| `tx_type` | `ORDERTX`, `LENDTX`, `None` | Type of active order |
-| `on_chain` | `true`, `false` | Whether account exists on-chain |
+| `index` | integer | Unique identifier within the wallet (used as `--account-index` everywhere) |
+| `balance` | integer (satoshis) | Current balance |
+| `qq_address` | hex string | QuisQuis encrypted account = public key + ElGamal commitment. Changes on every transfer (this is why an address can only be used once) |
+| `account` | string | Derived account address used for on-chain lookups (`tx-hashes --by account`, `request-history`) |
+| `scalar` | hex string | Randomness scalar used in the ElGamal commitment. Secret — part of the wallet DB, never exposed on-chain |
+| `io_type` | `Coin` / `Memo` / `State` | Account state on ZkOS (see below) |
+| `tx_type` | `ORDERTX` / `LENDTX` / `None` | Type of active order when `io_type = Memo` |
+| `on_chain` | `true` / `false` | Whether the account currently exists on-chain (set false after transfer/withdraw) |
 
-**State transitions:**
-- `Coin` = idle, ready for orders or transfers
-- `Memo` = locked in an active order
-- After close + unlock: back to `Coin`, but **must transfer before reuse**
+### State meanings and transitions
+
+- **`Coin`** — idle UTXO, ready for new orders or transfers.
+- **`Memo`** — locked in an active order; `tx_type` indicates which kind (`ORDERTX` = trade, `LENDTX` = lend).
+- **`State`** — on-chain initialization state, used briefly during account setup.
+
+After `close-trade` + `unlock-close-order`, the account returns to `Coin` with a new balance (margin ± PnL), but **the address is spent** — must run `zkaccount transfer` before opening a new order from that account.
 
 ---
 
@@ -263,6 +366,31 @@ Coin → open-trade → Memo (PENDING)
 
 `--order-type LIMIT` **cannot** be combined with `--stop-loss` or `--take-profit`.
 
+### Close-trade examples
+
+```bash
+# MARKET close (default) — immediate close at market price
+relayer-cli order close-trade --account-index 0
+
+# LIMIT close — settles when price hits 70000
+relayer-cli order close-trade --account-index 0 --order-type LIMIT --execution-price 70000
+
+# SLTP close — sets stop-loss 60000 and take-profit 75000, position stays open until a trigger fires
+relayer-cli order close-trade --account-index 0 --stop-loss 60000 --take-profit 75000
+
+# SLTP with only stop-loss (same pattern for take-profit alone)
+relayer-cli order close-trade --account-index 0 --stop-loss 60000
+
+# Remove a settle_limit set by a prior LIMIT close (position stays open)
+relayer-cli order cancel-trade --account-index 0
+
+# Remove stop-loss only (keeps take-profit, keeps position open)
+relayer-cli order cancel-trade --account-index 0 --stop-loss
+
+# Remove both SL and TP
+relayer-cli order cancel-trade --account-index 0 --stop-loss --take-profit
+```
+
 ### Lend order
 
 ```
@@ -270,6 +398,69 @@ Coin → open-lend → Memo (PENDING) → fills → FILLED
   ├── close-lend → SETTLED → unlock → Coin
   └── failed     → unlock-failed-order → Coin
 ```
+
+### Lend position metrics (fields returned by `query-lend` / `portfolio summary`)
+
+| Field | Meaning |
+|---|---|
+| `deposit` | Original amount deposited into the pool (sats) |
+| `balance` | Current value of the position = `deposit + accrued yield` |
+| `npoolshare` | Fractional share of the total lending pool |
+| `payment` | Cumulative interest/yield payment received |
+| `apr` | Annualised percentage rate (from v1 API) |
+
+### Order status reference (values in `order_status` field across `query-trade`, `query-lend`, `history-*`)
+
+| Status | When it applies | Next action |
+|---|---|---|
+| `PENDING` | Order submitted, waiting to be filled | `cancel-trade` (no flags) → `CANCELLED` |
+| `FILLED` | Matched/accepted, position is active | `close-trade` (MARKET/LIMIT/SLTP) or `close-lend` |
+| `SETTLED` | Position closed and settled | `unlock-close-order` → `Coin` |
+| `LIQUIDATE` | Position liquidated (trade only) | `unlock-close-order` → `Coin` |
+| `CANCELLED` | Cancelled before filling | Account already back to `Coin` |
+| `LENDED` | Internal lend state (rare, usually seen mid-settlement) | Wait for `SETTLED`, then unlock |
+
+### `unlock-close-order` routing
+
+The CLI uses the account's `tx_type` to pick the right unlock path:
+
+| `tx_type` | Action |
+|---|---|
+| `ORDERTX` | Query trader order, verify `SETTLED`/`LIQUIDATE`, fetch UTXO, restore to `Coin` |
+| `LENDTX` | Query lend order, verify `SETTLED`, fetch UTXO, restore to `Coin` |
+| `None` | Falls back to trader-order unlock (backward compat for pre-`tx_type` accounts) |
+
+`portfolio summary` auto-runs `unlock-close-order` for any settled/liquidated accounts it discovers, so you rarely need to call it manually if you check portfolio regularly.
+
+### Numeric constraints
+
+| Flag / input | Constraint |
+|---|---|
+| `order open-trade --leverage` | Integer in **1–50** |
+| `order open-trade --entry-price` | Integer USD (u64) — no decimals |
+| `order close-trade --execution-price` | Float, must be `> 0` when used with `--order-type LIMIT` |
+| `order close-trade --stop-loss` / `--take-profit` | Float, must be `> 0` |
+| `zkaccount split` | Creates **at most 8** new accounts per call (tx size limit) |
+| `zkaccount split --balances` | All entries must be `> 0`; sum must be `≤` source account balance |
+| Amount flags (`--amount`, `--amount-mbtc`, `--amount-btc`) | Provide exactly one; must be `> 0` |
+
+### Precondition cheat-sheet (common "why did this error?" cases)
+
+| Command | Required account state | Required order status | Other |
+|---|---|---|---|
+| `open-trade` | `Coin` + `on_chain` + **unused address** | — | Market not halted |
+| `open-lend` | `Coin` + `on_chain` + **unused address** | — | Market not halted |
+| `close-trade MARKET` | `Memo` + `ORDERTX` | `FILLED` | Market not halted |
+| `close-trade LIMIT` | `Memo` + `ORDERTX` | `FILLED` | `--execution-price > 0`; no `--stop-loss`/`--take-profit` |
+| `close-trade SLTP` | `Memo` + `ORDERTX` | `FILLED` | At least one of `--stop-loss`/`--take-profit`; no `LIMIT` |
+| `close-lend` | `Memo` + `LENDTX` | `FILLED` | — |
+| `cancel-trade` (no flags) | `Memo` | `PENDING` **or** `FILLED` with active `settle_limit` | — |
+| `cancel-trade --stop-loss` / `--take-profit` | `Memo` | `FILLED` with matching trigger | Trigger must exist |
+| `unlock-close-order` | `Memo` | `SETTLED` **or** `LIQUIDATE` | Errors otherwise (does not silently skip) |
+| `unlock-failed-order` | `Memo` with no active order | — | — |
+| `zkaccount transfer` / `withdraw` / `split` | `Coin` + `on_chain` | — | `split` sum ≤ balance, no zero balances |
+
+**"Unused address"** means the account has never been the source of an order. After `close-trade` + `unlock-close-order`, the address is spent — you must `zkaccount transfer` before opening a new order from that account (see [Critical Rule #1](#11-critical-rules)).
 
 ---
 
@@ -327,8 +518,18 @@ Coin → open-lend → Memo (PENDING) → fills → FILLED
 | `order history-lend` | Historical lend orders (from relayer) | Yes |
 | `order funding-history` | Funding payment history | Yes |
 | `order account-summary` | Trading activity summary | Yes |
-| `order tx-hashes` | Look up tx hashes by ID | **No** |
-| `order request-history` | Look up tx hashes by account index | Yes |
+| `order tx-hashes` | Look up tx hashes by `--id` + `--by request\|account\|tx` | **No** |
+| `order request-history` | Look up tx hashes by account index (resolves address from wallet) | Yes |
+
+### Bitcoin Wallet (on-chain BTC, not ZkOS)
+
+| Command | Purpose | Wallet needed? |
+|---|---|---|
+| `bitcoin-wallet balance` | On-chain BTC balance (confirmed + unconfirmed); `--btc` / `--mbtc` for units | Yes (or `--btc-address` for arbitrary lookup) |
+| `bitcoin-wallet transfer` | Send BTC to a native SegWit address (requires mnemonic-backed BTC wallet) | Yes |
+| `bitcoin-wallet receive` | Show BTC receive address, derivation path, QR code, registration status | Yes |
+| `bitcoin-wallet history` | BTC transfer history with confirmation status (`--status pending\|broadcast\|confirmed`) | Yes |
+| `bitcoin-wallet update-bitcoin-wallet` | Re-derive BTC keys from a new mnemonic (only if BTC address not yet registered) | Yes |
 
 ### Market (no wallet needed)
 
@@ -372,6 +573,14 @@ Coin → open-lend → Memo (PENDING) → fills → FILLED
 |---|---|
 | `history orders` | Order history (open/close/cancel events) |
 | `history transfers` | Transfer history (fund/withdraw/transfer events) |
+
+### Misc
+
+| Command | Purpose |
+|---|---|
+| `repl [--wallet-id] [--password]` | Interactive REPL — loads wallet once, then runs commands without the `relayer-cli` prefix. See §4 for details |
+| `help [group]` | Inline help — `relayer-cli help` for overview, `relayer-cli help <group>` (e.g. `order`, `wallet`) for group details |
+| `verify-test <wallet\|market\|zkaccount\|order\|all>` | **Testnet only** — runs self-tests against live testnet. Developer tool; requires funded wallet for `zkaccount`/`order` suites |
 
 ---
 
@@ -419,7 +628,16 @@ relayer-cli order open-trade --account-index 5 --side SHORT --entry-price 70000 
 
 1. **Account address reuse**: A ZkOS account address can only be used for **one order**. After close + unlock, you **must** `zkaccount transfer` before placing a new order.
 
-2. **Reserve timing**: BTC reserves rotate every ~144 blocks (~24h). The reserve must be ACTIVE when your BTC tx confirms. Status: ACTIVE (>72 blocks) > WARNING (5-72) > CRITICAL (<=4, don't send) > EXPIRED (0, don't send).
+2. **Reserve timing**: A BTC *reserve* is a validator-controlled Bitcoin address that the protocol uses to custody deposited BTC. Reserves **rotate every ~144 Bitcoin blocks (~24h)** — a new reserve becomes ACTIVE and the old one is swept. You send BTC to the current ACTIVE reserve; validators then credit your Twilight wallet with an equivalent SATS balance. The reserve must **still be ACTIVE when your BTC transaction confirms on Bitcoin** (~10 min + validator confirmation, ~1h+ total). Check `wallet reserves` before sending. Status table:
+
+   | Status | Blocks left | Safe to send? |
+   |---|---|---|
+   | ACTIVE | > 72 | Yes |
+   | WARNING | 5 – 72 | Only if tx will confirm quickly |
+   | CRITICAL | ≤ 4 | **No** — tx likely won't confirm in time |
+   | EXPIRED | 0 | **No** — reserve is being swept |
+
+   If all reserves are expired/critical, wait for the next rotation; `wallet reserves` shows ETA.
 
 3. **Registered address only**: BTC deposits must come from your registered BTC address. Sending from any other address will not be credited.
 
@@ -437,45 +655,67 @@ relayer-cli order open-trade --account-index 5 --side SHORT --entry-price 70000 
 
 ## 12. Error Recovery
 
-| Situation | Command |
+| Situation | Command / Resolution |
 |---|---|
 | Order submission failed, account stuck in Memo | `order unlock-failed-order --account-index N` |
 | Order settled but account still Memo | `order unlock-close-order --account-index N` |
 | Want to reuse account after order | `zkaccount transfer --account-index N` |
 | Nonce/sequence mismatch | `wallet sync-nonce` |
-| Deposit stuck as pending | Check `wallet deposit-status`, ensure BTC tx has 1+ confirmations, wait for validators |
 | "Value Witness Verification Failed" on open-trade | Account address was already used — run `zkaccount transfer` first |
-| All reserves expired | Wait for rotation (~144 blocks). `wallet reserves` shows ETA |
+| All reserves expired / critical | Wait for rotation (~144 blocks, ~24h). `wallet reserves` shows ETA |
+| `register-btc` says "BTC address is already registered to your wallet" | Already done — use `wallet deposit-btc` instead for subsequent deposits |
+| "BTC address is registered to a different twilight address" | Another wallet already owns this BTC address on-chain — use a different BTC address (`wallet update-btc-address`) |
+| Deposit stuck as pending for >1h | (1) Confirm BTC tx has 1+ confirmations on mempool explorer, (2) confirm BTC was sent from your *registered* BTC address, (3) confirm the target reserve was still ACTIVE at confirmation time, (4) rerun `wallet deposit-status` |
+| `register-btc` / `deposit-btc` says "Failed to estimate fee" | If BTC just arrived, wait for 1 confirmation and retry; otherwise CLI falls back to a 2,000 sat fee buffer |
+| `bitcoin-wallet update-bitcoin-wallet` rejected | Current BTC address is already registered on-chain and can't be changed. Either continue using it, or create a fresh wallet |
+| "BTC wallet not available" on auto-pay | Wallet was created without a mnemonic — either re-import with a mnemonic, or use the manual deposit flow (§6) |
 
 ---
 
 ## 13. JSON Output
 
-All commands support `--json` for machine-readable output. Common patterns:
+`--json` is a global flag — it works on every command. Use the shape table below to parse the result.
+
+| Command category | JSON shape |
+|---|---|
+| Submitters (`open-trade`, `close-trade`, `cancel-trade`, `open-lend`, `close-lend`, `register-btc`, `deposit-btc`, `withdraw-btc`, `send`, `zkaccount fund/withdraw/transfer/split`) | `{"request_id": "..."}` (and/or tx-hash fields) |
+| Queries (`query-trade`, `query-lend`, `history-*`, `funding-history`, `account-summary`, `tx-hashes`, `request-history`) | Full object (`TraderOrderV1`, `LendOrderV1`, arrays of records, etc.) |
+| Market (`price`, `orderbook`, `funding-rate`, `candles`, …) | Raw value or object from the relayer |
+| Unlocks (`unlock-close-order`) | `{"account_index": N, "order_status": "...", "request_id": "..."}` |
+| Unlocks (`unlock-failed-order`) | `{"account_index": N, "status": "unlocked"}` |
+| Wallet info (`balance`, `info`, `accounts`, `reserves`, `deposit-status`, `withdraw-status`) | Object with the corresponding fields |
+| Portfolio (`summary`, `balances`, `risks`) | Full portfolio JSON |
+
+Example:
 
 ```bash
-# Commands that submit orders/actions return request_id
-relayer-cli --json order open-trade ...    # {"request_id": "..."}
-relayer-cli --json order close-trade ...   # {"request_id": "..."}
-relayer-cli --json order cancel-trade ...  # {"request_id": "..."}
+relayer-cli --json order open-trade --account-index 0 --side LONG --entry-price 65000 --leverage 5
+# → {"request_id": "..."}
 
-# Query commands return full JSON objects
-relayer-cli --json order query-trade --account-index 0   # TraderOrderV1 JSON
-relayer-cli --json order query-lend --account-index 0    # LendOrderV1 JSON
-relayer-cli --json market price                          # price value
-
-# Unlock commands return status
-relayer-cli --json order unlock-close-order ...   # {"account_index": N, "order_status": "...", "request_id": "..."}
-relayer-cli --json order unlock-failed-order ...  # {"account_index": N, "status": "unlocked"}
+relayer-cli --json order query-trade --account-index 0
+# → full TraderOrderV1 object with order_status, entry_nonce, settle_limit, stop_loss, take_profit, funding_applied, ...
 ```
 
 ---
 
-## 14. Further Reading
+## 14. Getting Unstuck
 
-| Document | Contents |
-|---|---|
-| [relayer-cli.md](relayer-cli.md) | Full CLI reference — every flag, every output column |
-| [cli-command-rules.md](cli-command-rules.md) | Preconditions and requirements for every command |
-| [order-lifecycle.md](order-lifecycle.md) | ZkAccount states, trade/lend lifecycle diagrams |
-| [btc-onboarding.md](btc-onboarding.md) | BTC deposit/withdrawal flow with troubleshooting |
+If a command fails and §12 doesn't cover it, use `relayer-cli help <group>` for inline flag/precondition reference — every command group has detailed help built into the binary:
+
+```bash
+relayer-cli help wallet
+relayer-cli help order
+relayer-cli help zkaccount
+relayer-cli help market
+relayer-cli help bitcoin-wallet
+relayer-cli help portfolio
+relayer-cli help history
+relayer-cli help update
+```
+
+Each command also supports `--help` for per-subcommand flag details:
+
+```bash
+relayer-cli order close-trade --help
+relayer-cli wallet register-btc --help
+```

--- a/docs/agent-skill-relayer-cli.md
+++ b/docs/agent-skill-relayer-cli.md
@@ -6,23 +6,23 @@ A complete guide for AI agents and developers to build, configure, and operate t
 
 ## 1. Quick Start (pre-built binary)
 
-Download a pre-built binary from [GitHub releases](https://github.com/twilight-project/nyks-wallet/releases) — no build tools required.
+Download the latest pre-built binary from [GitHub releases](https://github.com/twilight-project/nyks-wallet/releases) — no build tools required.
+
+### Install script (macOS / Linux)
 
 ```bash
-# macOS ARM64 (Apple Silicon)
-curl -LO https://github.com/twilight-project/nyks-wallet/releases/download/v0.1.1-relayer-cli/nyks-wallet-macos-arm64
-mv nyks-wallet-macos-arm64 relayer-cli
-chmod +x relayer-cli
-
-# Linux x86_64
-curl -LO https://github.com/twilight-project/nyks-wallet/releases/download/v0.1.1-relayer-cli/nyks-wallet-linux-amd64
-mv nyks-wallet-linux-amd64 relayer-cli
-chmod +x relayer-cli
-
-# Windows x86_64
-curl -LO https://github.com/twilight-project/nyks-wallet/releases/download/v0.1.1-relayer-cli/nyks-wallet-windows-amd64.exe
-mv nyks-wallet-windows-amd64.exe relayer-cli.exe
+curl -sSfL https://raw.githubusercontent.com/twilight-project/nyks-wallet/main/install.sh | sh
 ```
+
+This auto-detects your platform, downloads the latest release, and installs `relayer-cli` in the current directory.
+
+### Install script (Windows PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/twilight-project/nyks-wallet/main/install.ps1 | iex
+```
+
+### Verify
 
 ```bash
 ./relayer-cli --help

--- a/docs/agent-skill-relayer-cli.md
+++ b/docs/agent-skill-relayer-cli.md
@@ -28,6 +28,15 @@ mv nyks-wallet-windows-amd64.exe relayer-cli.exe
 ./relayer-cli --help
 ```
 
+### Updating
+
+Once installed, the CLI can update itself:
+
+```bash
+relayer-cli update            # download and install the latest version
+relayer-cli update --check    # check if an update is available
+```
+
 ---
 
 ## 2. Build from Source
@@ -350,6 +359,12 @@ Coin → open-lend → Memo (PENDING) → fills → FILLED
 | `portfolio summary` | Full portfolio: balances, positions, PnL (auto-unlocks settled) |
 | `portfolio balances` | Per-account balance breakdown (`--unit sats\|mbtc\|btc`) |
 | `portfolio risks` | Liquidation risk for open positions |
+
+### Update
+
+| Command | Purpose |
+|---|---|
+| `update` | Check for updates and self-update the binary (`--check` for dry run) |
 
 ### History (from local DB)
 

--- a/docs/relayer-cli.md
+++ b/docs/relayer-cli.md
@@ -135,6 +135,7 @@ relayer-cli [--json] <COMMAND>
 - `portfolio` — portfolio summary, balances (with unit conversion), liquidation risks
 - `verify-test` — run verification tests against testnet (testnet only)
 - `repl` — interactive REPL mode with line editing, history, and a persistent wallet session
+- `update` — check for updates and self-update the binary
 - `help` — show help for the CLI or a specific command group
 
 ### Built-in Help
@@ -1615,6 +1616,28 @@ twilight1a...z123> market price
 twilight1a...z123> exit
 Goodbye.
 ```
+
+---
+
+## Update Command
+
+Check for new releases and self-update the binary in-place. Fetches the latest release from [GitHub releases](https://github.com/twilight-project/nyks-wallet/releases), compares versions, and downloads the correct platform-specific binary.
+
+### `update`
+
+```bash
+# Check and install the latest version
+relayer-cli update
+
+# Check only (no download)
+relayer-cli update --check
+```
+
+| Flag      | Description                                          |
+| --------- | ---------------------------------------------------- |
+| `--check` | Check for a new version without downloading or installing |
+
+The command detects the current platform automatically (macOS ARM64, Linux x86_64, Windows x86_64) and downloads the matching binary. On success, restart the CLI to use the new version.
 
 ---
 

--- a/docs/relayer-cli.md
+++ b/docs/relayer-cli.md
@@ -2,6 +2,26 @@
 
 Command-line interface for managing Twilight wallets, trading orders, lending, portfolio tracking, transaction history, and querying market data.
 
+## Pre-built Binary
+
+Pre-built binaries are published on [GitHub releases](https://github.com/twilight-project/nyks-wallet/releases). Use them to skip the Rust toolchain and `protoc`/`libpq` setup.
+
+**macOS / Linux:**
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/twilight-project/nyks-wallet/main/install.sh | sh
+```
+
+**Windows (PowerShell):**
+
+```powershell
+irm https://raw.githubusercontent.com/twilight-project/nyks-wallet/main/install.ps1 | iex
+```
+
+The script auto-detects your platform, downloads the matching archive, and installs `relayer-cli` in the current directory. Verify with `./relayer-cli --help`, and self-update later with `relayer-cli update` (or `relayer-cli update --check` for a dry run).
+
+> **Backend:** The pre-built binary is compiled with the **default feature set** — `sqlite` + `order-wallet` (see `Cargo.toml` `[features]`). SQLite is bundled, so no system SQLite library is required. If you need the **PostgreSQL** backend (`--features postgresql`), the pre-built binary will not work — build from source using the instructions below.
+
 ## Building
 
 ### Prerequisites

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,51 @@
+<#
+.SYNOPSIS
+    Install the latest relayer-cli binary for Windows.
+.DESCRIPTION
+    Downloads the latest relayer-cli release from GitHub and places it in the current directory.
+.EXAMPLE
+    .\install.ps1
+.EXAMPLE
+    irm https://raw.githubusercontent.com/twilight-project/nyks-wallet/main/install.ps1 | iex
+#>
+
+& {
+    $ErrorActionPreference = "Stop"
+
+    $Repo = "twilight-project/nyks-wallet"
+    $ApiUrl = "https://api.github.com/repos/$Repo/releases/latest"
+    $Artifact = "nyks-wallet-windows-amd64.exe"
+    $BinaryName = "relayer-cli.exe"
+
+    Write-Host "Fetching latest release from $Repo..."
+
+    try {
+        $Release = Invoke-RestMethod -Uri $ApiUrl -Headers @{ "User-Agent" = "relayer-cli-installer" }
+    } catch {
+        Write-Host "Error: Failed to fetch release info from GitHub API: $_" -ForegroundColor Red
+        return
+    }
+
+    $Asset = $Release.assets | Where-Object { $_.name -eq $Artifact }
+
+    if (-not $Asset) {
+        Write-Host "Error: Could not find asset '$Artifact' in latest release" -ForegroundColor Red
+        return
+    }
+
+    $Tag = $Release.tag_name
+    $DownloadUrl = $Asset.browser_download_url
+
+    Write-Host "Downloading $Tag ($Artifact)..."
+
+    try {
+        Invoke-WebRequest -Uri $DownloadUrl -OutFile $BinaryName -UseBasicParsing
+    } catch {
+        Write-Host "Error: Download failed: $_" -ForegroundColor Red
+        return
+    }
+
+    Write-Host ""
+    Write-Host "Installed $BinaryName $Tag to .\$BinaryName"
+    Write-Host "Run .\$BinaryName --help to get started."
+}

--- a/install.ps1
+++ b/install.ps1
@@ -29,15 +29,22 @@
         return
     }
 
-    # Filter to stable releases whose tag ends with '-relayer-cli' and pick the one
-    # with the highest semver. GitHub's default ordering is creation date, which we
-    # don't fully trust, so sort by parsed version instead.
+    # Filter to stable releases whose tag ends with '-relayer-cli' and which have
+    # both the platform binary and its .sha256 uploaded. Requiring the checksum
+    # ensures we skip releases whose workflow is still building — the release tag
+    # exists the moment it is created, but assets are uploaded 30–40 minutes later
+    # when the matrix build finishes. Without this check we'd error out with
+    # "could not find a relayer-cli asset" during that window. The workflow
+    # uploads the binary first and the checksum second, so a present checksum
+    # means the binary is fully uploaded too.
     $RelayerReleases = $Releases | Where-Object {
-        -not $_.draft -and -not $_.prerelease -and $_.tag_name -match '-relayer-cli$'
+        -not $_.draft -and -not $_.prerelease -and $_.tag_name -match '-relayer-cli$' -and
+        ($_.assets | Where-Object { $_.name.EndsWith($PlatformSuffix) -and -not $_.name.EndsWith(".sha256") }) -and
+        ($_.assets | Where-Object { $_.name.EndsWith("$PlatformSuffix.sha256") })
     }
 
     if (-not $RelayerReleases) {
-        Write-Host "Error: no release found with tag suffix '-relayer-cli'" -ForegroundColor Red
+        Write-Host "Error: no published relayer-cli release with assets for platform '$PlatformSuffix'. A newer release may still be building." -ForegroundColor Red
         return
     }
 
@@ -50,15 +57,9 @@
 
     $Tag = $Release.tag_name
 
-    # Binary asset: ends with platform suffix, not a .sha256 file.
     $Asset = $Release.assets | Where-Object {
         $_.name.EndsWith($PlatformSuffix) -and -not $_.name.EndsWith(".sha256")
     } | Select-Object -First 1
-
-    if (-not $Asset) {
-        Write-Host "Error: Could not find a relayer-cli asset for platform '$PlatformSuffix' in release $Tag" -ForegroundColor Red
-        return
-    }
 
     $DownloadUrl = $Asset.browser_download_url
 

--- a/install.ps1
+++ b/install.ps1
@@ -3,6 +3,7 @@
     Install the latest relayer-cli binary for Windows.
 .DESCRIPTION
     Downloads the latest relayer-cli release from GitHub and places it in the current directory.
+    Verifies the download against a SHA256 checksum if available.
 .EXAMPLE
     .\install.ps1
 .EXAMPLE
@@ -43,6 +44,34 @@
     } catch {
         Write-Host "Error: Download failed: $_" -ForegroundColor Red
         return
+    }
+
+    # --- Verify checksum ---
+
+    $ChecksumAsset = $Release.assets | Where-Object { $_.name -eq "$Artifact.sha256" }
+
+    if ($ChecksumAsset) {
+        Write-Host "Verifying checksum..."
+
+        try {
+            $ChecksumContent = Invoke-RestMethod -Uri $ChecksumAsset.browser_download_url -Headers @{ "User-Agent" = "relayer-cli-installer" }
+            $Expected = ($ChecksumContent -split '\s+')[0].ToUpper()
+            $Actual = (Get-FileHash $BinaryName -Algorithm SHA256).Hash
+
+            if ($Actual -ne $Expected) {
+                Write-Host "Error: checksum mismatch!" -ForegroundColor Red
+                Write-Host "  Expected: $Expected" -ForegroundColor Red
+                Write-Host "  Actual:   $Actual" -ForegroundColor Red
+                Remove-Item $BinaryName -Force
+                return
+            }
+
+            Write-Host "Checksum verified."
+        } catch {
+            Write-Host "Warning: could not verify checksum, skipping: $_" -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "Note: no checksum file found in release, skipping verification"
     }
 
     Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -3,7 +3,9 @@
     Install the latest relayer-cli binary for Windows.
 .DESCRIPTION
     Downloads the latest relayer-cli release from GitHub and places it in the current directory.
-    Verifies the download against a SHA256 checksum if available.
+    Verifies the download against a SHA256 checksum if available. Filters releases by the
+    '-relayer-cli' tag suffix so unrelated tags (validator-wallet, relayer-deployer, etc.)
+    are ignored.
 .EXAMPLE
     .\install.ps1
 .EXAMPLE
@@ -14,30 +16,53 @@
     $ErrorActionPreference = "Stop"
 
     $Repo = "twilight-project/nyks-wallet"
-    $ApiUrl = "https://api.github.com/repos/$Repo/releases/latest"
-    $Artifact = "nyks-wallet-windows-amd64.exe"
+    $ApiUrl = "https://api.github.com/repos/$Repo/releases?per_page=100"
+    $PlatformSuffix = "_windows_amd64.exe"
     $BinaryName = "relayer-cli.exe"
 
-    Write-Host "Fetching latest release from $Repo..."
+    Write-Host "Fetching releases from $Repo..."
 
     try {
-        $Release = Invoke-RestMethod -Uri $ApiUrl -Headers @{ "User-Agent" = "relayer-cli-installer" }
+        $Releases = Invoke-RestMethod -Uri $ApiUrl -Headers @{ "User-Agent" = "relayer-cli-installer" }
     } catch {
-        Write-Host "Error: Failed to fetch release info from GitHub API: $_" -ForegroundColor Red
+        Write-Host "Error: Failed to fetch releases from GitHub API: $_" -ForegroundColor Red
         return
     }
 
-    $Asset = $Release.assets | Where-Object { $_.name -eq $Artifact }
+    # Filter to stable releases whose tag ends with '-relayer-cli' and pick the one
+    # with the highest semver. GitHub's default ordering is creation date, which we
+    # don't fully trust, so sort by parsed version instead.
+    $RelayerReleases = $Releases | Where-Object {
+        -not $_.draft -and -not $_.prerelease -and $_.tag_name -match '-relayer-cli$'
+    }
 
-    if (-not $Asset) {
-        Write-Host "Error: Could not find asset '$Artifact' in latest release" -ForegroundColor Red
+    if (-not $RelayerReleases) {
+        Write-Host "Error: no release found with tag suffix '-relayer-cli'" -ForegroundColor Red
         return
     }
+
+    $Release = $RelayerReleases | Sort-Object -Property @{
+        Expression = {
+            $v = $_.tag_name -replace '^v', '' -replace '-relayer-cli$', ''
+            try { [version]$v } catch { [version]"0.0.0" }
+        }
+    } -Descending | Select-Object -First 1
 
     $Tag = $Release.tag_name
+
+    # Binary asset: ends with platform suffix, not a .sha256 file.
+    $Asset = $Release.assets | Where-Object {
+        $_.name.EndsWith($PlatformSuffix) -and -not $_.name.EndsWith(".sha256")
+    } | Select-Object -First 1
+
+    if (-not $Asset) {
+        Write-Host "Error: Could not find a relayer-cli asset for platform '$PlatformSuffix' in release $Tag" -ForegroundColor Red
+        return
+    }
+
     $DownloadUrl = $Asset.browser_download_url
 
-    Write-Host "Downloading $Tag ($Artifact)..."
+    Write-Host "Downloading $Tag ($($Asset.name))..."
 
     try {
         Invoke-WebRequest -Uri $DownloadUrl -OutFile $BinaryName -UseBasicParsing
@@ -48,27 +73,49 @@
 
     # --- Verify checksum ---
 
-    $ChecksumAsset = $Release.assets | Where-Object { $_.name -eq "$Artifact.sha256" }
+    $ChecksumAsset = $Release.assets | Where-Object {
+        $_.name -eq "$($Asset.name).sha256"
+    } | Select-Object -First 1
 
     if ($ChecksumAsset) {
         Write-Host "Verifying checksum..."
 
+        # Fetch raw checksum file content. Use Invoke-WebRequest rather than
+        # Invoke-RestMethod because the .sha256 asset is served as
+        # application/octet-stream, which Invoke-RestMethod may decode into a
+        # byte[] instead of a string.
+        $Expected = $null
         try {
-            $ChecksumContent = Invoke-RestMethod -Uri $ChecksumAsset.browser_download_url -Headers @{ "User-Agent" = "relayer-cli-installer" }
-            $Expected = ($ChecksumContent -split '\s+')[0].ToUpper()
+            $ChecksumResponse = Invoke-WebRequest `
+                -Uri $ChecksumAsset.browser_download_url `
+                -Headers @{ "User-Agent" = "relayer-cli-installer" } `
+                -UseBasicParsing
+            $ChecksumText = [string]$ChecksumResponse.Content
+            $Expected = ($ChecksumText -split '\s+')[0].ToUpper()
+        } catch {
+            Write-Host "Warning: could not download checksum, skipping verification: $_" -ForegroundColor Yellow
+        }
+
+        if ($Expected) {
             $Actual = (Get-FileHash $BinaryName -Algorithm SHA256).Hash
 
             if ($Actual -ne $Expected) {
                 Write-Host "Error: checksum mismatch!" -ForegroundColor Red
                 Write-Host "  Expected: $Expected" -ForegroundColor Red
                 Write-Host "  Actual:   $Actual" -ForegroundColor Red
-                Remove-Item $BinaryName -Force
+
+                # Best-effort cleanup. If the file can't be removed (locked,
+                # antivirus, permissions), warn but still abort — we must NOT
+                # fall through to the success path with a bad binary on disk.
+                try {
+                    Remove-Item $BinaryName -Force
+                } catch {
+                    Write-Host "Warning: failed to remove corrupt binary at .\$BinaryName — delete it manually." -ForegroundColor Yellow
+                }
                 return
             }
 
             Write-Host "Checksum verified."
-        } catch {
-            Write-Host "Warning: could not verify checksum, skipping: $_" -ForegroundColor Yellow
         }
     } else {
         Write-Host "Note: no checksum file found in release, skipping verification"

--- a/install.sh
+++ b/install.sh
@@ -41,18 +41,17 @@ RELEASES_JSON="$(curl -sf "${API_URL}")" || {
     exit 1
 }
 
-# Pick the newest download URL whose filename matches the relayer-cli asset
-# for this platform. Works regardless of whether GitHub returns pretty-printed
-# or compact JSON: we extract the URL with a single regex rather than relying
-# on line-by-line grep + field-cut. GitHub returns releases newest-first, so
-# the first match is the latest relayer-cli release, which naturally ignores
-# unrelated tags like v0.1.1 or v0.0.4-relayer-deployer.
-#
-# The regex stops at `_relayer_cli${PLATFORM_SUFFIX}` (without `.sha256`), so
-# both binary and checksum URLs in the JSON produce the same binary URL here.
-DOWNLOAD_URL="$(echo "${RELEASES_JSON}" \
-    | grep -oE "https://github\.com/[^\"]+_relayer_cli${PLATFORM_SUFFIX}" \
+# Pick the newest release whose `.sha256` asset for this platform is already
+# uploaded, then derive the binary URL from it. The release workflow uploads
+# the binary first and the checksum second, so a present `.sha256` means the
+# binary is fully uploaded too. This makes us skip releases whose build is
+# still in progress (the release exists but assets aren't uploaded yet) and
+# fall back to the previous fully-published release.
+CHECKSUM_URL="$(echo "${RELEASES_JSON}" \
+    | grep -oE "https://github\.com/[^\"]+_relayer_cli${PLATFORM_SUFFIX}\.sha256" \
     | head -1)"
+
+DOWNLOAD_URL="${CHECKSUM_URL%.sha256}"
 
 if [ -z "${DOWNLOAD_URL}" ]; then
     echo "Error: could not find a relayer-cli asset for platform ${PLATFORM_SUFFIX}" >&2
@@ -74,8 +73,6 @@ curl -sfL "${DOWNLOAD_URL}" -o "${INSTALL_DIR}/${BINARY_NAME}" || {
 }
 
 # --- Verify checksum ---------------------------------------------------------
-
-CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
 
 echo "Verifying checksum..."
 

--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,37 @@ curl -sfL "${DOWNLOAD_URL}" -o "${INSTALL_DIR}/${BINARY_NAME}" || {
     exit 1
 }
 
+# --- Verify checksum ---------------------------------------------------------
+
+CHECKSUM_URL="$(echo "${RELEASE_JSON}" | grep "browser_download_url" | grep "${ARTIFACT}.sha256" | head -1 | cut -d '"' -f 4)"
+
+if [ -n "${CHECKSUM_URL}" ] && [ "${CHECKSUM_URL}" != "null" ]; then
+    echo "Verifying checksum..."
+
+    EXPECTED="$(curl -sfL "${CHECKSUM_URL}" | cut -d ' ' -f 1)"
+
+    if [ -z "${EXPECTED}" ]; then
+        echo "Warning: could not download checksum file, skipping verification" >&2
+    else
+        # shasum works on both macOS and Linux
+        ACTUAL="$(shasum -a 256 "${INSTALL_DIR}/${BINARY_NAME}" | cut -d ' ' -f 1)"
+
+        if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+            echo "Error: checksum mismatch!" >&2
+            echo "  Expected: ${EXPECTED}" >&2
+            echo "  Actual:   ${ACTUAL}" >&2
+            rm -f "${INSTALL_DIR}/${BINARY_NAME}"
+            exit 1
+        fi
+
+        echo "Checksum verified."
+    fi
+else
+    echo "Note: no checksum file found in release, skipping verification"
+fi
+
+# --- Finalize ----------------------------------------------------------------
+
 chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
 
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 REPO="twilight-project/nyks-wallet"
-API_URL="https://api.github.com/repos/${REPO}/releases/latest"
+API_URL="https://api.github.com/repos/${REPO}/releases?per_page=100"
 INSTALL_DIR="."
 BINARY_NAME="relayer-cli"
 
@@ -12,50 +12,54 @@ OS="$(uname -s)"
 ARCH="$(uname -m)"
 
 case "${OS}" in
-    Linux)  ARTIFACT="nyks-wallet-linux-amd64" ;;
-    Darwin) ARTIFACT="nyks-wallet-macos-arm64" ;;
-    *)      echo "Error: unsupported OS: ${OS}" >&2; exit 1 ;;
-esac
-
-case "${ARCH}" in
-    x86_64|amd64)
-        if [ "${OS}" = "Linux" ]; then
-            ARTIFACT="nyks-wallet-linux-amd64"
-        else
-            echo "Error: macOS x86_64 is not supported (Apple Silicon only)" >&2; exit 1
-        fi
+    Linux)
+        case "${ARCH}" in
+            x86_64|amd64)    PLATFORM_SUFFIX="_linux_amd64" ;;
+            arm64|aarch64)   PLATFORM_SUFFIX="_linux_arm64" ;;
+            *) echo "Error: unsupported Linux architecture: ${ARCH}" >&2; exit 1 ;;
+        esac
         ;;
-    arm64|aarch64)
-        if [ "${OS}" = "Darwin" ]; then
-            ARTIFACT="nyks-wallet-macos-arm64"
-        else
-            ARTIFACT="nyks-wallet-linux-arm64"
-        fi
+    Darwin)
+        case "${ARCH}" in
+            arm64|aarch64)   PLATFORM_SUFFIX="_macos_arm64" ;;
+            *) echo "Error: macOS x86_64 is not supported (Apple Silicon only)" >&2; exit 1 ;;
+        esac
         ;;
     *)
-        echo "Error: unsupported architecture: ${ARCH}" >&2; exit 1
+        echo "Error: unsupported OS: ${OS}" >&2; exit 1
         ;;
 esac
 
-echo "Detected platform: ${OS} ${ARCH} -> ${ARTIFACT}"
+echo "Detected platform: ${OS} ${ARCH} -> ${PLATFORM_SUFFIX}"
 
-# --- Fetch latest release URL -----------------------------------------------
+# --- Fetch releases list ----------------------------------------------------
 
-echo "Fetching latest release from ${REPO}..."
+echo "Fetching releases from ${REPO}..."
 
-RELEASE_JSON="$(curl -sf "${API_URL}")" || {
-    echo "Error: failed to fetch release info from GitHub API" >&2
+RELEASES_JSON="$(curl -sf "${API_URL}")" || {
+    echo "Error: failed to fetch releases from GitHub API" >&2
     exit 1
 }
 
-# Extract download URL and tag via grep — works regardless of JSON body encoding
-DOWNLOAD_URL="$(echo "${RELEASE_JSON}" | grep "browser_download_url" | grep "${ARTIFACT}" | head -1 | cut -d '"' -f 4)"
-TAG="$(echo "${RELEASE_JSON}" | grep '"tag_name"' | head -1 | cut -d '"' -f 4)"
+# Pick the newest browser_download_url whose filename matches the
+# relayer-cli asset for this platform. GitHub returns releases newest-first,
+# so the first match is the latest relayer-cli release. This naturally
+# ignores unrelated tags like v0.1.1 or v0.0.4-relayer-deployer.
+DOWNLOAD_URL="$(echo "${RELEASES_JSON}" \
+    | grep '"browser_download_url"' \
+    | grep "_relayer_cli${PLATFORM_SUFFIX}\"" \
+    | head -1 \
+    | cut -d '"' -f 4)"
 
-if [ -z "${DOWNLOAD_URL}" ] || [ "${DOWNLOAD_URL}" = "null" ]; then
-    echo "Error: could not find asset '${ARTIFACT}' in latest release" >&2
+if [ -z "${DOWNLOAD_URL}" ]; then
+    echo "Error: could not find a relayer-cli asset for platform ${PLATFORM_SUFFIX}" >&2
     exit 1
 fi
+
+# Extract the tag from the download URL path:
+# https://github.com/OWNER/REPO/releases/download/<TAG>/<ASSET>
+TAG="$(echo "${DOWNLOAD_URL}" | awk -F'/releases/download/' '{print $2}' | awk -F'/' '{print $1}')"
+ARTIFACT="$(echo "${DOWNLOAD_URL}" | awk -F'/' '{print $NF}')"
 
 echo "Downloading ${TAG} (${ARTIFACT})..."
 
@@ -68,31 +72,27 @@ curl -sfL "${DOWNLOAD_URL}" -o "${INSTALL_DIR}/${BINARY_NAME}" || {
 
 # --- Verify checksum ---------------------------------------------------------
 
-CHECKSUM_URL="$(echo "${RELEASE_JSON}" | grep "browser_download_url" | grep "${ARTIFACT}.sha256" | head -1 | cut -d '"' -f 4)"
+CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
 
-if [ -n "${CHECKSUM_URL}" ] && [ "${CHECKSUM_URL}" != "null" ]; then
-    echo "Verifying checksum..."
+echo "Verifying checksum..."
 
-    EXPECTED="$(curl -sfL "${CHECKSUM_URL}" | cut -d ' ' -f 1)"
+EXPECTED="$(curl -sfL "${CHECKSUM_URL}" 2>/dev/null | cut -d ' ' -f 1)"
 
-    if [ -z "${EXPECTED}" ]; then
-        echo "Warning: could not download checksum file, skipping verification" >&2
-    else
-        # shasum works on both macOS and Linux
-        ACTUAL="$(shasum -a 256 "${INSTALL_DIR}/${BINARY_NAME}" | cut -d ' ' -f 1)"
-
-        if [ "${ACTUAL}" != "${EXPECTED}" ]; then
-            echo "Error: checksum mismatch!" >&2
-            echo "  Expected: ${EXPECTED}" >&2
-            echo "  Actual:   ${ACTUAL}" >&2
-            rm -f "${INSTALL_DIR}/${BINARY_NAME}"
-            exit 1
-        fi
-
-        echo "Checksum verified."
-    fi
+if [ -z "${EXPECTED}" ]; then
+    echo "Warning: no checksum file found for ${ARTIFACT}, skipping verification" >&2
 else
-    echo "Note: no checksum file found in release, skipping verification"
+    # shasum works on both macOS and Linux
+    ACTUAL="$(shasum -a 256 "${INSTALL_DIR}/${BINARY_NAME}" | cut -d ' ' -f 1)"
+
+    if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+        echo "Error: checksum mismatch!" >&2
+        echo "  Expected: ${EXPECTED}" >&2
+        echo "  Actual:   ${ACTUAL}" >&2
+        rm -f "${INSTALL_DIR}/${BINARY_NAME}"
+        exit 1
+    fi
+
+    echo "Checksum verified."
 fi
 
 # --- Finalize ----------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -48,14 +48,9 @@ RELEASE_JSON="$(curl -sf "${API_URL}")" || {
     exit 1
 }
 
-# Extract download URL — try jq first, fall back to grep+cut
-if command -v jq >/dev/null 2>&1; then
-    DOWNLOAD_URL="$(echo "${RELEASE_JSON}" | jq -r ".assets[] | select(.name == \"${ARTIFACT}\") | .browser_download_url")"
-    TAG="$(echo "${RELEASE_JSON}" | jq -r '.tag_name')"
-else
-    DOWNLOAD_URL="$(echo "${RELEASE_JSON}" | grep "browser_download_url" | grep "${ARTIFACT}" | head -1 | cut -d '"' -f 4)"
-    TAG="$(echo "${RELEASE_JSON}" | grep '"tag_name"' | head -1 | cut -d '"' -f 4)"
-fi
+# Extract download URL and tag via grep — works regardless of JSON body encoding
+DOWNLOAD_URL="$(echo "${RELEASE_JSON}" | grep "browser_download_url" | grep "${ARTIFACT}" | head -1 | cut -d '"' -f 4)"
+TAG="$(echo "${RELEASE_JSON}" | grep '"tag_name"' | head -1 | cut -d '"' -f 4)"
 
 if [ -z "${DOWNLOAD_URL}" ] || [ "${DOWNLOAD_URL}" = "null" ]; then
     echo "Error: could not find asset '${ARTIFACT}' in latest release" >&2

--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,9 @@ case "${ARCH}" in
         if [ "${OS}" = "Darwin" ]; then
             ARTIFACT="nyks-wallet-macos-arm64"
         else
-            echo "Error: Linux ARM64 is not supported" >&2; exit 1
+            # No native Linux ARM64 build — use x86_64 binary (works under emulation, e.g. Docker on Apple Silicon)
+            echo "Note: no native Linux ARM64 build available, using x86_64 binary"
+            ARTIFACT="nyks-wallet-linux-amd64"
         fi
         ;;
     *)

--- a/install.sh
+++ b/install.sh
@@ -41,15 +41,18 @@ RELEASES_JSON="$(curl -sf "${API_URL}")" || {
     exit 1
 }
 
-# Pick the newest browser_download_url whose filename matches the
-# relayer-cli asset for this platform. GitHub returns releases newest-first,
-# so the first match is the latest relayer-cli release. This naturally
-# ignores unrelated tags like v0.1.1 or v0.0.4-relayer-deployer.
+# Pick the newest download URL whose filename matches the relayer-cli asset
+# for this platform. Works regardless of whether GitHub returns pretty-printed
+# or compact JSON: we extract the URL with a single regex rather than relying
+# on line-by-line grep + field-cut. GitHub returns releases newest-first, so
+# the first match is the latest relayer-cli release, which naturally ignores
+# unrelated tags like v0.1.1 or v0.0.4-relayer-deployer.
+#
+# The regex stops at `_relayer_cli${PLATFORM_SUFFIX}` (without `.sha256`), so
+# both binary and checksum URLs in the JSON produce the same binary URL here.
 DOWNLOAD_URL="$(echo "${RELEASES_JSON}" \
-    | grep '"browser_download_url"' \
-    | grep "_relayer_cli${PLATFORM_SUFFIX}\"" \
-    | head -1 \
-    | cut -d '"' -f 4)"
+    | grep -oE "https://github\.com/[^\"]+_relayer_cli${PLATFORM_SUFFIX}" \
+    | head -1)"
 
 if [ -z "${DOWNLOAD_URL}" ]; then
     echo "Error: could not find a relayer-cli asset for platform ${PLATFORM_SUFFIX}" >&2

--- a/install.sh
+++ b/install.sh
@@ -29,9 +29,7 @@ case "${ARCH}" in
         if [ "${OS}" = "Darwin" ]; then
             ARTIFACT="nyks-wallet-macos-arm64"
         else
-            # No native Linux ARM64 build — use x86_64 binary (works under emulation, e.g. Docker on Apple Silicon)
-            echo "Note: no native Linux ARM64 build available, using x86_64 binary"
-            ARTIFACT="nyks-wallet-linux-amd64"
+            ARTIFACT="nyks-wallet-linux-arm64"
         fi
         ;;
     *)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+set -e
+
+REPO="twilight-project/nyks-wallet"
+API_URL="https://api.github.com/repos/${REPO}/releases/latest"
+INSTALL_DIR="."
+BINARY_NAME="relayer-cli"
+
+# --- Detect platform --------------------------------------------------------
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "${OS}" in
+    Linux)  ARTIFACT="nyks-wallet-linux-amd64" ;;
+    Darwin) ARTIFACT="nyks-wallet-macos-arm64" ;;
+    *)      echo "Error: unsupported OS: ${OS}" >&2; exit 1 ;;
+esac
+
+case "${ARCH}" in
+    x86_64|amd64)
+        if [ "${OS}" = "Linux" ]; then
+            ARTIFACT="nyks-wallet-linux-amd64"
+        else
+            echo "Error: macOS x86_64 is not supported (Apple Silicon only)" >&2; exit 1
+        fi
+        ;;
+    arm64|aarch64)
+        if [ "${OS}" = "Darwin" ]; then
+            ARTIFACT="nyks-wallet-macos-arm64"
+        else
+            echo "Error: Linux ARM64 is not supported" >&2; exit 1
+        fi
+        ;;
+    *)
+        echo "Error: unsupported architecture: ${ARCH}" >&2; exit 1
+        ;;
+esac
+
+echo "Detected platform: ${OS} ${ARCH} -> ${ARTIFACT}"
+
+# --- Fetch latest release URL -----------------------------------------------
+
+echo "Fetching latest release from ${REPO}..."
+
+RELEASE_JSON="$(curl -sf "${API_URL}")" || {
+    echo "Error: failed to fetch release info from GitHub API" >&2
+    exit 1
+}
+
+# Extract download URL — try jq first, fall back to grep+cut
+if command -v jq >/dev/null 2>&1; then
+    DOWNLOAD_URL="$(echo "${RELEASE_JSON}" | jq -r ".assets[] | select(.name == \"${ARTIFACT}\") | .browser_download_url")"
+    TAG="$(echo "${RELEASE_JSON}" | jq -r '.tag_name')"
+else
+    DOWNLOAD_URL="$(echo "${RELEASE_JSON}" | grep "browser_download_url" | grep "${ARTIFACT}" | head -1 | cut -d '"' -f 4)"
+    TAG="$(echo "${RELEASE_JSON}" | grep '"tag_name"' | head -1 | cut -d '"' -f 4)"
+fi
+
+if [ -z "${DOWNLOAD_URL}" ] || [ "${DOWNLOAD_URL}" = "null" ]; then
+    echo "Error: could not find asset '${ARTIFACT}' in latest release" >&2
+    exit 1
+fi
+
+echo "Downloading ${TAG} (${ARTIFACT})..."
+
+# --- Download and install ----------------------------------------------------
+
+curl -sfL "${DOWNLOAD_URL}" -o "${INSTALL_DIR}/${BINARY_NAME}" || {
+    echo "Error: download failed" >&2
+    exit 1
+}
+
+chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+
+echo ""
+echo "Installed ${BINARY_NAME} ${TAG} to ${INSTALL_DIR}/${BINARY_NAME}"
+echo "Run ./${BINARY_NAME} --help to get started."

--- a/src/bin/relayer_cli/help.rs
+++ b/src/bin/relayer_cli/help.rs
@@ -37,9 +37,13 @@ RESOLUTION PRIORITY (wallet-id & password):
     --flag  >  session cache (wallet unlock)  >  env var
 
 ENVIRONMENT:
+    NETWORK_TYPE            Nyks network (mainnet/testnet, default: mainnet)
     NYKS_WALLET_ID          Default wallet ID
     NYKS_WALLET_PASSPHRASE  Default password
-    BTC_NETWORK_TYPE        Bitcoin network (mainnet/testnet, falls back to mainnet)
+    BTC_NETWORK_TYPE        BTC network for key derivation (default: mainnet).
+                            Keep as mainnet even with NETWORK_TYPE=testnet —
+                            the Nyks chain only supports BTC mainnet. Only
+                            override to testnet for local bitcoin-wallet testing.
 
 REPL MODE:
     relayer-cli repl                     # interactive prompt for wallet ID & password
@@ -110,17 +114,24 @@ SUBCOMMANDS:
     transfer    Transfer balance between ZkOS trading accounts
     split       Split one account into multiple new accounts
 
-AMOUNTS:
-    fund/split accept amounts in multiple units (pick one):
-        --amount <sats>           Satoshis
-        --amount-mbtc <mbtc>      Milli-BTC (1 mBTC = 100,000 sats)
-        --amount-btc <btc>        BTC (1 BTC = 100,000,000 sats)
+AMOUNTS (fund — pick exactly one):
+    --amount <sats>           Satoshis
+    --amount-mbtc <mbtc>      Milli-BTC (1 mBTC = 100,000 sats)
+    --amount-btc <btc>        BTC (1 BTC = 100,000,000 sats)
+
+BALANCES (split — comma-separated list, pick exactly one):
+    --balances "1000,2000"        Satoshis per new account
+    --balances-mbtc "0.01,0.02"   Milli-BTC per new account
+    --balances-btc "0.00001,…"    BTC per new account
+    (max 8 new accounts per split call; no zero values; sum ≤ source balance)
 
 EXAMPLES:
     relayer-cli zkaccount fund --amount 50000
+    relayer-cli zkaccount fund --amount-btc 0.0005
     relayer-cli zkaccount withdraw --account-index 1
     relayer-cli zkaccount transfer --account-index 1
-    relayer-cli zkaccount split --account-index 0 --balances "10000,20000,30000""#
+    relayer-cli zkaccount split --account-index 0 --balances "10000,20000,30000"
+    relayer-cli zkaccount split --account-index 0 --balances-mbtc "0.1,0.2""#
     );
 }
 
@@ -133,10 +144,15 @@ USAGE:
 
 TRADING:
     open-trade          Open a leveraged position (MARKET/LIMIT)
-    close-trade         Close a position (MARKET/LIMIT/SLTP)
-    cancel-trade        Cancel a pending order or cancel SL/TP on a filled order
+    close-trade         Close a position. Modes:
+                          MARKET (default) — immediate close at market price
+                          LIMIT  — --order-type LIMIT --execution-price <P>
+                          SLTP   — --stop-loss <P> and/or --take-profit <P>
+                        (LIMIT cannot be combined with --stop-loss / --take-profit)
+    cancel-trade        No flags: cancel PENDING order, or remove settle_limit on FILLED
+                        --stop-loss / --take-profit: remove SL/TP triggers on FILLED
     query-trade         Query current order status
-    unlock-close-order  Unlock a settled order (trade or lend) based on account's TXType
+    unlock-close-order  Unlock a settled order (trade or lend) based on account's tx_type
     unlock-failed-order Unlock a failed order (reclaim account when submission failed)
 
 LENDING:
@@ -155,15 +171,19 @@ HISTORY & ANALYTICS (from relayer):
 EXAMPLES:
     relayer-cli order open-trade --account-index 1 --side LONG --entry-price 65000 --leverage 5
     relayer-cli order close-trade --account-index 1
+    relayer-cli order close-trade --account-index 1 --order-type LIMIT --execution-price 70000
+    relayer-cli order close-trade --account-index 1 --stop-loss 60000 --take-profit 75000
+    relayer-cli order cancel-trade --account-index 1              # cancel PENDING or remove settle_limit
+    relayer-cli order cancel-trade --account-index 1 --stop-loss  # remove SL only (position stays open)
+    relayer-cli order cancel-trade --account-index 1 --stop-loss --take-profit
     relayer-cli order query-trade --account-index 1
     relayer-cli order history-trade --account-index 1
-    relayer-cli order cancel-trade --account-index 1 --stop-loss --take-profit
     relayer-cli order account-summary --from 2024-01-01 --to 2024-12-31
     relayer-cli order request-history --account-index 0
     relayer-cli order request-history --account-index 0 --status FILLED --reason
 
 NOTE:
-    If the account was previously used for a open/closed order. You must transfer the account
+    If the account was previously used for an open/closed order, you must transfer the account
     first before placing a new order, as an order cannot be placed with the same
     account address twice. If the order was pending to fill and later cancelled, you can reuse the
     account.
@@ -193,10 +213,10 @@ LIVE DATA:
     server-time         Relayer server time
 
 HISTORICAL DATA:
-    history-price       Historical prices over a date range
-    candles             OHLCV candlestick data
-    history-funding     Historical funding rates
-    history-fees        Historical fee rates
+    history-price       Historical prices over a date range (requires --from, --to)
+    candles             OHLCV candlestick data (requires --since)
+    history-funding     Historical funding rates (requires --from, --to)
+    history-fees        Historical fee rates (requires --from, --to)
     apy-chart           APY chart data for lend pool
 
 EXAMPLES:
@@ -251,10 +271,12 @@ USAGE:
     relayer-cli bitcoin-wallet <SUBCOMMAND>
 
 SUBCOMMANDS:
-    balance     Check on-chain BTC balance (confirmed + unconfirmed)
-    transfer    Send BTC to a native SegWit address
-    receive     Show BTC receive address and wallet details
-    history     Show BTC transfer history with confirmation status
+    balance                 Check on-chain BTC balance (confirmed + unconfirmed)
+    transfer                Send BTC to a native SegWit address
+    receive                 Show BTC receive address and wallet details
+    history                 Show BTC transfer history with confirmation status
+    update-bitcoin-wallet   Re-derive BTC keys from a new mnemonic (only if
+                            current BTC address is not yet registered on-chain)
 
 AMOUNTS (transfer):
     --amount <sats>           Satoshis (priority 1)
@@ -274,7 +296,8 @@ EXAMPLES:
     relayer-cli bitcoin-wallet transfer --to bc1q... --amount-mbtc 0.5 --fee-rate 5
     relayer-cli bitcoin-wallet receive
     relayer-cli bitcoin-wallet history
-    relayer-cli bitcoin-wallet history --status confirmed"#
+    relayer-cli bitcoin-wallet history --status confirmed
+    relayer-cli bitcoin-wallet update-bitcoin-wallet --mnemonic "<phrase>""#
     );
 }
 
@@ -326,6 +349,7 @@ pub(crate) fn print_subcommand_help(group: &str) {
         "portfolio" => print_portfolio_help(),
         "verifytest" => print_verify_test_help(),
         "update" => print_update_help(),
+        "repl" => crate::repl::print_repl_help(),
         _ => {
             eprintln!("Unknown command group: '{}'\n", group);
             print_global_help();

--- a/src/bin/relayer_cli/help.rs
+++ b/src/bin/relayer_cli/help.rs
@@ -28,6 +28,7 @@ COMMANDS:
     repl            Interactive REPL mode — enter wallet ID and password once,
                     then run commands without the `relayer-cli` prefix
     verify-test     Run verification tests against testnet (testnet only)
+    update          Check for updates and self-update the binary
 
 GLOBAL FLAGS:
     --json      Output results as JSON (for scripting)
@@ -298,6 +299,22 @@ EXAMPLES:
     );
 }
 
+pub(crate) fn print_update_help() {
+    println!(
+        r#"Check for updates and self-update the binary.
+
+USAGE:
+    relayer-cli update [--check]
+
+FLAGS:
+    --check     Check for a new version without downloading or installing
+
+EXAMPLES:
+    relayer-cli update              # download and install the latest version
+    relayer-cli update --check      # check if an update is available"#
+    );
+}
+
 pub(crate) fn print_subcommand_help(group: &str) {
     match group.to_lowercase().replace('-', "").as_str() {
         "wallet" => print_wallet_help(),
@@ -308,6 +325,7 @@ pub(crate) fn print_subcommand_help(group: &str) {
         "history" => print_history_help(),
         "portfolio" => print_portfolio_help(),
         "verifytest" => print_verify_test_help(),
+        "update" => print_update_help(),
         _ => {
             eprintln!("Unknown command group: '{}'\n", group);
             print_global_help();

--- a/src/bin/relayer_cli/main.rs
+++ b/src/bin/relayer_cli/main.rs
@@ -9,6 +9,7 @@ mod market;
 mod order;
 mod portfolio;
 mod repl;
+mod update;
 mod verify_test;
 mod wallet;
 mod zkaccount;
@@ -78,6 +79,13 @@ enum Commands {
         password: Option<String>,
     },
 
+    /// Check for updates and self-update the binary
+    Update {
+        /// Check only — show available version without downloading
+        #[arg(long, default_value_t = false)]
+        check: bool,
+    },
+
     /// Show help for a command group (e.g. `help wallet`)
     Help {
         /// Command group to get help for (wallet, zkaccount, order, market, history, portfolio)
@@ -107,6 +115,7 @@ async fn main() {
         Commands::Portfolio(cmd) => portfolio::handle_portfolio(cmd, json_output, None).await,
         Commands::BitcoinWallet(cmd) => bitcoin_wallet::handle_bitcoin_wallet(cmd, None).await,
         Commands::VerifyTest(cmd) => verify_test::handle_verify_test(cmd).await,
+        Commands::Update { check } => update::handle_update(check).await,
         Commands::Repl { wallet_id, password } => {
             repl::run_repl(wallet_id, password).await
         }

--- a/src/bin/relayer_cli/main.rs
+++ b/src/bin/relayer_cli/main.rs
@@ -20,9 +20,18 @@ use commands::*;
 // CLI definition
 // ---------------------------------------------------------------------------
 
+const VERSION_INFO: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (",
+    env!("BUILD_DATE"),
+    ")\nhttps://github.com/twilight-project/nyks-wallet/releases/tag/v",
+    env!("CARGO_PKG_VERSION"),
+    "-relayer-cli"
+);
+
 /// Twilight Relayer CLI — manage wallets and orders from the command line.
 #[derive(Parser)]
-#[command(name = "relayer-cli", version, about, long_about = None, disable_help_subcommand = true)]
+#[command(name = "relayer-cli", version = VERSION_INFO, about, long_about = None, disable_help_subcommand = true)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/src/bin/relayer_cli/repl.rs
+++ b/src/bin/relayer_cli/repl.rs
@@ -306,7 +306,7 @@ fn dirs_home() -> std::path::PathBuf {
 // REPL-specific help
 // ---------------------------------------------------------------------------
 
-fn print_repl_help() {
+pub(crate) fn print_repl_help() {
     println!(
         r#"Relayer REPL — interactive mode
 

--- a/src/bin/relayer_cli/update.rs
+++ b/src/bin/relayer_cli/update.rs
@@ -34,12 +34,22 @@ struct GithubAsset {
     browser_download_url: String,
 }
 
-fn pick_latest_relayer_release(mut releases: Vec<GithubRelease>) -> Option<GithubRelease> {
+fn pick_latest_relayer_release(
+    mut releases: Vec<GithubRelease>,
+    suffix: &str,
+) -> Option<GithubRelease> {
+    // Require both the binary and checksum to be uploaded. The release
+    // workflow uploads them together, but while a build is still in progress
+    // the release tag already exists with empty or partial assets. Skipping
+    // those lets us fall back to the previous fully-published release instead
+    // of erroring out with "no asset found for this platform".
     releases.retain(|r| {
         !r.draft
             && !r.prerelease
             && r.tag_name.ends_with(RELEASE_TAG_SUFFIX)
             && parse_version(&r.tag_name).is_ok()
+            && find_binary_asset(&r.assets, suffix).is_some()
+            && find_checksum_asset(&r.assets, suffix).is_some()
     });
     releases.sort_by_key(|r| parse_version(&r.tag_name).unwrap_or((0, 0, 0)));
     releases.pop()
@@ -112,6 +122,8 @@ pub(crate) async fn handle_update(check_only: bool) -> Result<(), String> {
 
     println!("Checking for updates...");
 
+    let suffix = artifact_suffix()?;
+
     let releases: Vec<GithubRelease> = client
         .get(GITHUB_API_URL)
         .send()
@@ -121,8 +133,10 @@ pub(crate) async fn handle_update(check_only: bool) -> Result<(), String> {
         .await
         .map_err(|e| format!("Failed to parse release JSON: {e}"))?;
 
-    let release = pick_latest_relayer_release(releases).ok_or_else(|| {
-        format!("No release found with tag suffix '{RELEASE_TAG_SUFFIX}'.")
+    let release = pick_latest_relayer_release(releases, suffix).ok_or_else(|| {
+        format!(
+            "No release found with tag suffix '{RELEASE_TAG_SUFFIX}' and assets for this platform ('{suffix}'). A newer release may still be building."
+        )
     })?;
 
     let remote = parse_version(&release.tag_name)?;
@@ -144,7 +158,6 @@ pub(crate) async fn handle_update(check_only: bool) -> Result<(), String> {
         return Ok(());
     }
 
-    let suffix = artifact_suffix()?;
     let asset = find_binary_asset(&release.assets, suffix)
         .ok_or_else(|| format!("No asset found for this platform (suffix '{suffix}')."))?;
 
@@ -432,6 +445,21 @@ mod tests {
     // -----------------------------------------------------------------------
 
     fn make_release(tag: &str, draft: bool, prerelease: bool) -> GithubRelease {
+        // Tests default to a release with the linux_amd64 binary + checksum
+        // uploaded, since `pick_latest_relayer_release` now requires that.
+        let version = tag.trim_end_matches(RELEASE_TAG_SUFFIX);
+        GithubRelease {
+            tag_name: tag.to_string(),
+            draft,
+            prerelease,
+            assets: vec![
+                asset(&format!("nw_{version}_relayer_cli_linux_amd64")),
+                asset(&format!("nw_{version}_relayer_cli_linux_amd64.sha256")),
+            ],
+        }
+    }
+
+    fn make_release_without_assets(tag: &str, draft: bool, prerelease: bool) -> GithubRelease {
         GithubRelease {
             tag_name: tag.to_string(),
             draft,
@@ -450,7 +478,8 @@ mod tests {
             make_release("v0.0.2-validator-wallet", false, false),
             make_release("v0.1.4-realyer-cli", false, false), // typo, must be skipped
         ];
-        let picked = pick_latest_relayer_release(releases).expect("should pick a release");
+        let picked = pick_latest_relayer_release(releases, "_linux_amd64")
+            .expect("should pick a release");
         assert_eq!(picked.tag_name, "v0.1.9-relayer-cli");
     }
 
@@ -461,7 +490,8 @@ mod tests {
             make_release("v0.1.9-relayer-cli", false, true),  // prerelease
             make_release("v0.1.8-relayer-cli", false, false), // stable
         ];
-        let picked = pick_latest_relayer_release(releases).expect("should pick a release");
+        let picked = pick_latest_relayer_release(releases, "_linux_amd64")
+            .expect("should pick a release");
         assert_eq!(picked.tag_name, "v0.1.8-relayer-cli");
     }
 
@@ -471,12 +501,38 @@ mod tests {
             make_release("v0.1.1", false, false),
             make_release("v0.0.4-relayer-deployer", false, false),
         ];
-        assert!(pick_latest_relayer_release(releases).is_none());
+        assert!(pick_latest_relayer_release(releases, "_linux_amd64").is_none());
     }
 
     #[test]
     fn returns_none_on_empty_input() {
-        assert!(pick_latest_relayer_release(vec![]).is_none());
+        assert!(pick_latest_relayer_release(vec![], "_linux_amd64").is_none());
+    }
+
+    #[test]
+    fn skips_release_with_missing_assets_for_platform() {
+        // Newest release is still being built — tag exists but binary+checksum
+        // haven't been uploaded yet. We should fall back to the previous
+        // fully-published release instead of returning None or erroring.
+        let releases = vec![
+            make_release_without_assets("v0.2.0-relayer-cli", false, false),
+            make_release("v0.1.9-relayer-cli", false, false),
+        ];
+        let picked = pick_latest_relayer_release(releases, "_linux_amd64")
+            .expect("should fall back to v0.1.9");
+        assert_eq!(picked.tag_name, "v0.1.9-relayer-cli");
+    }
+
+    #[test]
+    fn skips_release_missing_checksum_for_platform() {
+        // Simulates partial upload: binary uploaded, checksum not yet.
+        let mut partial = make_release_without_assets("v0.2.0-relayer-cli", false, false);
+        partial.assets.push(asset("nw_v0.2.0_relayer_cli_linux_amd64"));
+
+        let releases = vec![partial, make_release("v0.1.9-relayer-cli", false, false)];
+        let picked = pick_latest_relayer_release(releases, "_linux_amd64")
+            .expect("should fall back to v0.1.9");
+        assert_eq!(picked.tag_name, "v0.1.9-relayer-cli");
     }
 
     // -----------------------------------------------------------------------

--- a/src/bin/relayer_cli/update.rs
+++ b/src/bin/relayer_cli/update.rs
@@ -1,3 +1,4 @@
+use sha2::{Digest, Sha256};
 use std::io::Write;
 
 const GITHUB_API_URL: &str =
@@ -111,6 +112,43 @@ pub(crate) async fn handle_update(check_only: bool) -> Result<(), String> {
         .map_err(|e| format!("Failed to read download: {e}"))?;
 
     println!("Downloaded {} bytes.", bytes.len());
+
+    // --- Verify checksum --------------------------------------------------------
+
+    let checksum_name = format!("{expected_name}.sha256");
+    let checksum_asset = release.assets.iter().find(|a| a.name == checksum_name);
+
+    if let Some(checksum_asset) = checksum_asset {
+        println!("Verifying checksum...");
+
+        let checksum_text = client
+            .get(&checksum_asset.browser_download_url)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to download checksum: {e}"))?
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read checksum: {e}"))?;
+
+        let expected = checksum_text
+            .split_whitespace()
+            .next()
+            .ok_or_else(|| "Checksum file is empty".to_string())?;
+
+        let actual = hex::encode(Sha256::digest(&bytes));
+
+        if actual != expected {
+            return Err(format!(
+                "Checksum mismatch!\n  Expected: {expected}\n  Actual:   {actual}"
+            ));
+        }
+
+        println!("Checksum verified.");
+    } else {
+        println!("Note: no checksum file in release, skipping verification.");
+    }
+
+    // --- Write and replace -------------------------------------------------------
 
     let tmp_path = std::env::temp_dir().join(format!("relayer-cli-update-{}", std::process::id()));
 

--- a/src/bin/relayer_cli/update.rs
+++ b/src/bin/relayer_cli/update.rs
@@ -1,13 +1,30 @@
 use sha2::{Digest, Sha256};
 use std::io::Write;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Removes a temp file on drop, so orphaned update artifacts aren't left
+/// behind in `$TMPDIR` when `handle_update` returns early via `?`.
+struct TempFileGuard(PathBuf);
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
 
 const GITHUB_API_URL: &str =
-    "https://api.github.com/repos/twilight-project/nyks-wallet/releases/latest";
+    "https://api.github.com/repos/twilight-project/nyks-wallet/releases?per_page=100";
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+const RELEASE_TAG_SUFFIX: &str = "-relayer-cli";
 
 #[derive(serde::Deserialize)]
 struct GithubRelease {
     tag_name: String,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    prerelease: bool,
     assets: Vec<GithubAsset>,
 }
 
@@ -17,15 +34,32 @@ struct GithubAsset {
     browser_download_url: String,
 }
 
-fn artifact_name() -> Result<&'static str, String> {
+fn pick_latest_relayer_release(mut releases: Vec<GithubRelease>) -> Option<GithubRelease> {
+    releases.retain(|r| {
+        !r.draft
+            && !r.prerelease
+            && r.tag_name.ends_with(RELEASE_TAG_SUFFIX)
+            && parse_version(&r.tag_name).is_ok()
+    });
+    releases.sort_by_key(|r| parse_version(&r.tag_name).unwrap_or((0, 0, 0)));
+    releases.pop()
+}
+
+/// Returns the platform-specific suffix that release asset names end with.
+///
+/// Release assets are named like `nw_v0.1.9_relayer_cli_linux_amd64` (binary)
+/// and `nw_v0.1.9_relayer_cli_linux_amd64.sha256` (checksum). Since the
+/// version prefix changes per release, we match by trailing platform segment
+/// instead of the full name.
+fn artifact_suffix() -> Result<&'static str, String> {
     if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
-        Ok("nyks-wallet-linux-amd64")
+        Ok("_linux_amd64")
     } else if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
-        Ok("nyks-wallet-linux-arm64")
+        Ok("_linux_arm64")
     } else if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
-        Ok("nyks-wallet-macos-arm64")
+        Ok("_macos_arm64")
     } else if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
-        Ok("nyks-wallet-windows-amd64.exe")
+        Ok("_windows_amd64.exe")
     } else {
         Err(format!(
             "Unsupported platform: {} / {}",
@@ -35,11 +69,22 @@ fn artifact_name() -> Result<&'static str, String> {
     }
 }
 
+fn find_binary_asset<'a>(assets: &'a [GithubAsset], suffix: &str) -> Option<&'a GithubAsset> {
+    assets
+        .iter()
+        .find(|a| a.name.ends_with(suffix) && !a.name.ends_with(".sha256"))
+}
+
+fn find_checksum_asset<'a>(assets: &'a [GithubAsset], suffix: &str) -> Option<&'a GithubAsset> {
+    let checksum_suffix = format!("{suffix}.sha256");
+    assets.iter().find(|a| a.name.ends_with(&checksum_suffix))
+}
+
 fn parse_version(s: &str) -> Result<(u32, u32, u32), String> {
     let stripped = s
         .strip_prefix('v')
         .unwrap_or(s)
-        .trim_end_matches("-relayer-cli");
+        .trim_end_matches(RELEASE_TAG_SUFFIX);
     let parts: Vec<&str> = stripped.split('.').collect();
     if parts.len() != 3 {
         return Err(format!("Invalid version: {s}"));
@@ -60,12 +105,14 @@ fn parse_version(s: &str) -> Result<(u32, u32, u32), String> {
 pub(crate) async fn handle_update(check_only: bool) -> Result<(), String> {
     let client = reqwest::Client::builder()
         .user_agent("relayer-cli-updater")
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(120))
         .build()
         .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
 
     println!("Checking for updates...");
 
-    let release: GithubRelease = client
+    let releases: Vec<GithubRelease> = client
         .get(GITHUB_API_URL)
         .send()
         .await
@@ -73,6 +120,10 @@ pub(crate) async fn handle_update(check_only: bool) -> Result<(), String> {
         .json()
         .await
         .map_err(|e| format!("Failed to parse release JSON: {e}"))?;
+
+    let release = pick_latest_relayer_release(releases).ok_or_else(|| {
+        format!("No release found with tag suffix '{RELEASE_TAG_SUFFIX}'.")
+    })?;
 
     let remote = parse_version(&release.tag_name)?;
     let local = parse_version(CURRENT_VERSION)?;
@@ -86,21 +137,21 @@ pub(crate) async fn handle_update(check_only: bool) -> Result<(), String> {
         .tag_name
         .strip_prefix('v')
         .unwrap_or(&release.tag_name)
-        .trim_end_matches("-relayer-cli");
+        .trim_end_matches(RELEASE_TAG_SUFFIX);
 
     if check_only {
         println!("Update available: v{CURRENT_VERSION} -> v{remote_display}");
         return Ok(());
     }
 
-    let expected_name = artifact_name()?;
-    let asset = release
-        .assets
-        .iter()
-        .find(|a| a.name == expected_name)
-        .ok_or_else(|| format!("No asset found for this platform: {expected_name}"))?;
+    let suffix = artifact_suffix()?;
+    let asset = find_binary_asset(&release.assets, suffix)
+        .ok_or_else(|| format!("No asset found for this platform (suffix '{suffix}')."))?;
 
-    println!("Updating v{CURRENT_VERSION} -> v{remote_display} ({expected_name})...");
+    println!(
+        "Updating v{CURRENT_VERSION} -> v{remote_display} ({})...",
+        asset.name
+    );
 
     let bytes = client
         .get(&asset.browser_download_url)
@@ -115,8 +166,7 @@ pub(crate) async fn handle_update(check_only: bool) -> Result<(), String> {
 
     // --- Verify checksum --------------------------------------------------------
 
-    let checksum_name = format!("{expected_name}.sha256");
-    let checksum_asset = release.assets.iter().find(|a| a.name == checksum_name);
+    let checksum_asset = find_checksum_asset(&release.assets, suffix);
 
     if let Some(checksum_asset) = checksum_asset {
         println!("Verifying checksum...");
@@ -150,7 +200,9 @@ pub(crate) async fn handle_update(check_only: bool) -> Result<(), String> {
 
     // --- Write and replace -------------------------------------------------------
 
-    let tmp_path = std::env::temp_dir().join(format!("relayer-cli-update-{}", std::process::id()));
+    let tmp_path =
+        std::env::temp_dir().join(format!("relayer-cli-update-{}", std::process::id()));
+    let _tmp_guard = TempFileGuard(tmp_path.clone());
 
     {
         let mut file = std::fs::File::create(&tmp_path)
@@ -167,8 +219,6 @@ pub(crate) async fn handle_update(check_only: bool) -> Result<(), String> {
     }
 
     self_replace::self_replace(&tmp_path).map_err(|e| format!("Failed to replace binary: {e}"))?;
-
-    let _ = std::fs::remove_file(&tmp_path);
 
     println!("Updated to v{remote_display}. Restart the CLI to use the new version.");
     Ok(())
@@ -231,42 +281,105 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // artifact_name
+    // artifact_suffix
     // -----------------------------------------------------------------------
 
     #[test]
-    fn artifact_name_returns_ok_on_supported_platform() {
-        // We're compiling on a supported platform (macOS ARM64, Linux x86_64, or Windows x86_64),
-        // so this should succeed. If CI adds an unsupported target, this test catches it.
-        let result = artifact_name();
+    fn artifact_suffix_returns_ok_on_supported_platform() {
+        let result = artifact_suffix();
         assert!(
             result.is_ok(),
-            "artifact_name() failed on this platform: {result:?}"
+            "artifact_suffix() failed on this platform: {result:?}"
         );
 
-        let name = result.unwrap();
-        println!("name: {name}");
+        let suffix = result.unwrap();
         assert!(
-            name == "nyks-wallet-linux-amd64"
-                || name == "nyks-wallet-linux-arm64"
-                || name == "nyks-wallet-macos-arm64"
-                || name == "nyks-wallet-windows-amd64.exe",
-            "unexpected artifact name: {name}"
+            suffix == "_linux_amd64"
+                || suffix == "_linux_arm64"
+                || suffix == "_macos_arm64"
+                || suffix == "_windows_amd64.exe",
+            "unexpected artifact suffix: {suffix}"
         );
     }
 
     #[test]
-    fn artifact_name_matches_current_platform() {
-        let name = artifact_name().unwrap();
+    fn artifact_suffix_matches_current_platform() {
+        let suffix = artifact_suffix().unwrap();
         if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
-            assert_eq!(name, "nyks-wallet-macos-arm64");
+            assert_eq!(suffix, "_macos_arm64");
         } else if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
-            assert_eq!(name, "nyks-wallet-linux-amd64");
+            assert_eq!(suffix, "_linux_amd64");
         } else if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
-            assert_eq!(name, "nyks-wallet-linux-arm64");
+            assert_eq!(suffix, "_linux_arm64");
         } else if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
-            assert_eq!(name, "nyks-wallet-windows-amd64.exe");
+            assert_eq!(suffix, "_windows_amd64.exe");
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // find_binary_asset / find_checksum_asset
+    // -----------------------------------------------------------------------
+
+    fn asset(name: &str) -> GithubAsset {
+        GithubAsset {
+            name: name.to_string(),
+            browser_download_url: format!("https://example/{name}"),
+        }
+    }
+
+    #[test]
+    fn find_binary_asset_picks_binary_not_checksum() {
+        let assets = vec![
+            asset("nw_v0.1.9_relayer_cli_linux_amd64"),
+            asset("nw_v0.1.9_relayer_cli_linux_amd64.sha256"),
+            asset("nw_v0.1.9_relayer_cli_linux_arm64"),
+        ];
+        let picked = find_binary_asset(&assets, "_linux_amd64").expect("should find asset");
+        assert_eq!(picked.name, "nw_v0.1.9_relayer_cli_linux_amd64");
+    }
+
+    #[test]
+    fn find_binary_asset_windows_matches_exe_not_sha256() {
+        let assets = vec![
+            asset("nw_v0.1.9_relayer_cli_windows_amd64.exe"),
+            asset("nw_v0.1.9_relayer_cli_windows_amd64.exe.sha256"),
+        ];
+        let picked = find_binary_asset(&assets, "_windows_amd64.exe").expect("should find asset");
+        assert_eq!(picked.name, "nw_v0.1.9_relayer_cli_windows_amd64.exe");
+    }
+
+    #[test]
+    fn find_binary_asset_missing_returns_none() {
+        let assets = vec![asset("nw_v0.1.9_relayer_cli_linux_amd64")];
+        assert!(find_binary_asset(&assets, "_macos_arm64").is_none());
+    }
+
+    #[test]
+    fn find_checksum_asset_picks_matching_checksum() {
+        let assets = vec![
+            asset("nw_v0.1.9_relayer_cli_linux_amd64"),
+            asset("nw_v0.1.9_relayer_cli_linux_amd64.sha256"),
+            asset("nw_v0.1.9_relayer_cli_linux_arm64.sha256"),
+        ];
+        let picked = find_checksum_asset(&assets, "_linux_amd64").expect("should find checksum");
+        assert_eq!(picked.name, "nw_v0.1.9_relayer_cli_linux_amd64.sha256");
+    }
+
+    #[test]
+    fn find_checksum_asset_windows_matches_exe_sha256() {
+        let assets = vec![
+            asset("nw_v0.1.9_relayer_cli_windows_amd64.exe"),
+            asset("nw_v0.1.9_relayer_cli_windows_amd64.exe.sha256"),
+        ];
+        let picked =
+            find_checksum_asset(&assets, "_windows_amd64.exe").expect("should find checksum");
+        assert_eq!(picked.name, "nw_v0.1.9_relayer_cli_windows_amd64.exe.sha256");
+    }
+
+    #[test]
+    fn find_checksum_asset_missing_returns_none() {
+        let assets = vec![asset("nw_v0.1.9_relayer_cli_linux_amd64")];
+        assert!(find_checksum_asset(&assets, "_linux_amd64").is_none());
     }
 
     // -----------------------------------------------------------------------
@@ -312,5 +425,90 @@ mod tests {
             result.is_ok(),
             "CARGO_PKG_VERSION is not parseable: {result:?}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // pick_latest_relayer_release
+    // -----------------------------------------------------------------------
+
+    fn make_release(tag: &str, draft: bool, prerelease: bool) -> GithubRelease {
+        GithubRelease {
+            tag_name: tag.to_string(),
+            draft,
+            prerelease,
+            assets: vec![],
+        }
+    }
+
+    #[test]
+    fn picks_highest_relayer_cli_tag_ignoring_other_components() {
+        let releases = vec![
+            make_release("v0.1.9-relayer-cli", false, false),
+            make_release("v0.1.8-relayer-cli", false, false),
+            make_release("v0.1.1", false, false),
+            make_release("v0.0.4-relayer-deployer", false, false),
+            make_release("v0.0.2-validator-wallet", false, false),
+            make_release("v0.1.4-realyer-cli", false, false), // typo, must be skipped
+        ];
+        let picked = pick_latest_relayer_release(releases).expect("should pick a release");
+        assert_eq!(picked.tag_name, "v0.1.9-relayer-cli");
+    }
+
+    #[test]
+    fn skips_drafts_and_prereleases() {
+        let releases = vec![
+            make_release("v0.2.0-relayer-cli", true, false),  // draft
+            make_release("v0.1.9-relayer-cli", false, true),  // prerelease
+            make_release("v0.1.8-relayer-cli", false, false), // stable
+        ];
+        let picked = pick_latest_relayer_release(releases).expect("should pick a release");
+        assert_eq!(picked.tag_name, "v0.1.8-relayer-cli");
+    }
+
+    #[test]
+    fn returns_none_when_no_relayer_cli_release() {
+        let releases = vec![
+            make_release("v0.1.1", false, false),
+            make_release("v0.0.4-relayer-deployer", false, false),
+        ];
+        assert!(pick_latest_relayer_release(releases).is_none());
+    }
+
+    #[test]
+    fn returns_none_on_empty_input() {
+        assert!(pick_latest_relayer_release(vec![]).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // TempFileGuard
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn temp_file_guard_removes_file_on_drop() {
+        let path = std::env::temp_dir().join(format!(
+            "relayer-cli-update-guard-test-{}",
+            std::process::id()
+        ));
+        std::fs::write(&path, b"scratch").expect("write scratch file");
+        assert!(path.exists(), "precondition: scratch file exists");
+
+        {
+            let _guard = TempFileGuard(path.clone());
+        }
+
+        assert!(!path.exists(), "guard should remove file on drop");
+    }
+
+    #[test]
+    fn temp_file_guard_missing_file_is_noop() {
+        let path = std::env::temp_dir().join(format!(
+            "relayer-cli-update-guard-missing-{}",
+            std::process::id()
+        ));
+        assert!(!path.exists(), "precondition: path does not exist");
+
+        // Must not panic even when the file was never created or was already
+        // consumed by self_replace.
+        let _guard = TempFileGuard(path);
     }
 }

--- a/src/bin/relayer_cli/update.rs
+++ b/src/bin/relayer_cli/update.rs
@@ -19,6 +19,8 @@ struct GithubAsset {
 fn artifact_name() -> Result<&'static str, String> {
     if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
         Ok("nyks-wallet-linux-amd64")
+    } else if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
+        Ok("nyks-wallet-linux-arm64")
     } else if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
         Ok("nyks-wallet-macos-arm64")
     } else if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
@@ -208,6 +210,7 @@ mod tests {
         println!("name: {name}");
         assert!(
             name == "nyks-wallet-linux-amd64"
+                || name == "nyks-wallet-linux-arm64"
                 || name == "nyks-wallet-macos-arm64"
                 || name == "nyks-wallet-windows-amd64.exe",
             "unexpected artifact name: {name}"
@@ -221,6 +224,8 @@ mod tests {
             assert_eq!(name, "nyks-wallet-macos-arm64");
         } else if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
             assert_eq!(name, "nyks-wallet-linux-amd64");
+        } else if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
+            assert_eq!(name, "nyks-wallet-linux-arm64");
         } else if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
             assert_eq!(name, "nyks-wallet-windows-amd64.exe");
         }

--- a/src/bin/relayer_cli/update.rs
+++ b/src/bin/relayer_cli/update.rs
@@ -1,0 +1,273 @@
+use std::io::Write;
+
+const GITHUB_API_URL: &str =
+    "https://api.github.com/repos/twilight-project/nyks-wallet/releases/latest";
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(serde::Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    assets: Vec<GithubAsset>,
+}
+
+#[derive(serde::Deserialize)]
+struct GithubAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+fn artifact_name() -> Result<&'static str, String> {
+    if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
+        Ok("nyks-wallet-linux-amd64")
+    } else if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        Ok("nyks-wallet-macos-arm64")
+    } else if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+        Ok("nyks-wallet-windows-amd64.exe")
+    } else {
+        Err(format!(
+            "Unsupported platform: {} / {}",
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        ))
+    }
+}
+
+fn parse_version(s: &str) -> Result<(u32, u32, u32), String> {
+    let stripped = s
+        .strip_prefix('v')
+        .unwrap_or(s)
+        .trim_end_matches("-relayer-cli");
+    let parts: Vec<&str> = stripped.split('.').collect();
+    if parts.len() != 3 {
+        return Err(format!("Invalid version: {s}"));
+    }
+    Ok((
+        parts[0]
+            .parse()
+            .map_err(|_| format!("Bad major: {}", parts[0]))?,
+        parts[1]
+            .parse()
+            .map_err(|_| format!("Bad minor: {}", parts[1]))?,
+        parts[2]
+            .parse()
+            .map_err(|_| format!("Bad patch: {}", parts[2]))?,
+    ))
+}
+
+pub(crate) async fn handle_update(check_only: bool) -> Result<(), String> {
+    let client = reqwest::Client::builder()
+        .user_agent("relayer-cli-updater")
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
+
+    println!("Checking for updates...");
+
+    let release: GithubRelease = client
+        .get(GITHUB_API_URL)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch release info: {e}"))?
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse release JSON: {e}"))?;
+
+    let remote = parse_version(&release.tag_name)?;
+    let local = parse_version(CURRENT_VERSION)?;
+
+    if remote <= local {
+        println!("Already up to date (v{CURRENT_VERSION}).");
+        return Ok(());
+    }
+
+    let remote_display = release
+        .tag_name
+        .strip_prefix('v')
+        .unwrap_or(&release.tag_name)
+        .trim_end_matches("-relayer-cli");
+
+    if check_only {
+        println!("Update available: v{CURRENT_VERSION} -> v{remote_display}");
+        return Ok(());
+    }
+
+    let expected_name = artifact_name()?;
+    let asset = release
+        .assets
+        .iter()
+        .find(|a| a.name == expected_name)
+        .ok_or_else(|| format!("No asset found for this platform: {expected_name}"))?;
+
+    println!("Updating v{CURRENT_VERSION} -> v{remote_display} ({expected_name})...");
+
+    let bytes = client
+        .get(&asset.browser_download_url)
+        .send()
+        .await
+        .map_err(|e| format!("Download failed: {e}"))?
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read download: {e}"))?;
+
+    println!("Downloaded {} bytes.", bytes.len());
+
+    let tmp_path = std::env::temp_dir().join(format!("relayer-cli-update-{}", std::process::id()));
+
+    {
+        let mut file = std::fs::File::create(&tmp_path)
+            .map_err(|e| format!("Failed to create temp file: {e}"))?;
+        file.write_all(&bytes)
+            .map_err(|e| format!("Failed to write temp file: {e}"))?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o755))
+            .map_err(|e| format!("Failed to set permissions: {e}"))?;
+    }
+
+    self_replace::self_replace(&tmp_path).map_err(|e| format!("Failed to replace binary: {e}"))?;
+
+    let _ = std::fs::remove_file(&tmp_path);
+
+    println!("Updated to v{remote_display}. Restart the CLI to use the new version.");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // parse_version
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_version_full_tag() {
+        assert_eq!(parse_version("v0.1.2-relayer-cli"), Ok((0, 1, 2)));
+    }
+
+    #[test]
+    fn parse_version_with_v_prefix_only() {
+        assert_eq!(parse_version("v1.2.3"), Ok((1, 2, 3)));
+    }
+
+    #[test]
+    fn parse_version_bare() {
+        assert_eq!(parse_version("0.1.2"), Ok((0, 1, 2)));
+    }
+
+    #[test]
+    fn parse_version_large_numbers() {
+        assert_eq!(
+            parse_version("v10.200.3000-relayer-cli"),
+            Ok((10, 200, 3000))
+        );
+    }
+
+    #[test]
+    fn parse_version_too_few_parts() {
+        assert!(parse_version("v1.2").is_err());
+    }
+
+    #[test]
+    fn parse_version_too_many_parts() {
+        assert!(parse_version("v1.2.3.4").is_err());
+    }
+
+    #[test]
+    fn parse_version_non_numeric() {
+        assert!(parse_version("v1.two.3").is_err());
+    }
+
+    #[test]
+    fn parse_version_empty() {
+        assert!(parse_version("").is_err());
+    }
+
+    #[test]
+    fn parse_version_just_suffix() {
+        assert!(parse_version("-relayer-cli").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // artifact_name
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn artifact_name_returns_ok_on_supported_platform() {
+        // We're compiling on a supported platform (macOS ARM64, Linux x86_64, or Windows x86_64),
+        // so this should succeed. If CI adds an unsupported target, this test catches it.
+        let result = artifact_name();
+        assert!(
+            result.is_ok(),
+            "artifact_name() failed on this platform: {result:?}"
+        );
+
+        let name = result.unwrap();
+        println!("name: {name}");
+        assert!(
+            name == "nyks-wallet-linux-amd64"
+                || name == "nyks-wallet-macos-arm64"
+                || name == "nyks-wallet-windows-amd64.exe",
+            "unexpected artifact name: {name}"
+        );
+    }
+
+    #[test]
+    fn artifact_name_matches_current_platform() {
+        let name = artifact_name().unwrap();
+        if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+            assert_eq!(name, "nyks-wallet-macos-arm64");
+        } else if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
+            assert_eq!(name, "nyks-wallet-linux-amd64");
+        } else if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+            assert_eq!(name, "nyks-wallet-windows-amd64.exe");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // version comparison ordering
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn version_ordering_newer_patch() {
+        let old = parse_version("v0.1.1-relayer-cli").unwrap();
+        let new = parse_version("v0.1.2-relayer-cli").unwrap();
+        assert!(new > old);
+    }
+
+    #[test]
+    fn version_ordering_newer_minor() {
+        let old = parse_version("v0.1.9").unwrap();
+        let new = parse_version("v0.2.0").unwrap();
+        assert!(new > old);
+    }
+
+    #[test]
+    fn version_ordering_newer_major() {
+        let old = parse_version("v0.99.99").unwrap();
+        let new = parse_version("v1.0.0").unwrap();
+        assert!(new > old);
+    }
+
+    #[test]
+    fn version_ordering_equal() {
+        let a = parse_version("v0.1.2-relayer-cli").unwrap();
+        let b = parse_version("0.1.2").unwrap();
+        assert_eq!(a, b);
+    }
+
+    // -----------------------------------------------------------------------
+    // CURRENT_VERSION is parseable
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn current_version_is_valid() {
+        let result = parse_version(CURRENT_VERSION);
+        assert!(
+            result.is_ok(),
+            "CARGO_PKG_VERSION is not parseable: {result:?}"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,37 +102,49 @@
 //! For lower-level access to relayer endpoints:
 //!
 //! ```no_run
+//! use nyks_wallet::config::RELAYER_API_RPC_SERVER_URL;
 //! use nyks_wallet::relayer_module::relayer_api::RelayerJsonRpcClient;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let client = RelayerJsonRpcClient::new("http://0.0.0.0:8088/api")?;
-//!     
+//!     let client = RelayerJsonRpcClient::new(&RELAYER_API_RPC_SERVER_URL)?;
+//!
 //!     // Get market data
 //!     let price = client.btc_usd_price().await?;
 //!     let order_book = client.open_limit_orders().await?;
 //!     let funding_rate = client.get_funding_rate().await?;
-//!     
+//!
 //!     println!("BTC/USD: ${}, Funding: {}%", price.price, funding_rate.rate);
-//!     
+//!
 //!     Ok(())
 //! }
 //! ```
 //!
 //! ## Environment Configuration
 //!
-//! The following environment variables can be used to configure endpoints and behavior:
+//! Endpoint defaults are selected by `NETWORK_TYPE` (mainnet vs testnet); override any
+//! variable explicitly to point at a local full-node.
 //!
 //! | Variable | Description | Default |
 //! |----------|-------------|---------|
-//! | `NYKS_RPC_BASE_URL` | Cosmos RPC endpoint | `http://0.0.0.0:26657` |
-//! | `NYKS_LCD_BASE_URL` | Cosmos LCD endpoint | `http://0.0.0.0:1317` |
-//! | `RELAYER_PROGRAM_JSON_PATH` | Path to relayer program config | `./relayerprogram.json` |
-//! | `PUBLIC_API_RPC_SERVER_URL` | Public relayer API endpoint | Various |
-//! | `RELAYER_RPC_SERVER_URL` | Relayer trading API endpoint | Various |
-//! | `FAUCET_BASE_URL` | Testnet faucet endpoint | Various |
-//! | `NYKS_WALLET_PASSPHRASE` | Database encryption passphrase | None |
-//! | `RUST_LOG` | Logging level | `info` |
+//! | `NETWORK_TYPE` | `mainnet` or `testnet`; selects defaults for other endpoints | `mainnet` |
+//! | `BTC_NETWORK_TYPE` | BTC network for Esplora endpoints (nyks chain only supports BTC `mainnet`) | `mainnet` |
+//! | `CHAIN_ID` | Target chain ID | `nyks` |
+//! | `NYKS_RPC_BASE_URL` | Cosmos / Tendermint RPC | mainnet: `https://rpc.twilight.org`; testnet: `https://rpc.twilight.rest` |
+//! | `NYKS_LCD_BASE_URL` | Cosmos LCD REST | mainnet: `https://lcd.twilight.org`; testnet: `https://lcd.twilight.rest` |
+//! | `RELAYER_API_RPC_SERVER_URL` | Relayer JSON-RPC API | mainnet: `https://api.ephemeral.fi/api`; testnet: `https://relayer.twilight.rest/api` |
+//! | `ZKOS_SERVER_URL` | ZkOS JSON-RPC | mainnet: `https://zkserver.twilight.org`; testnet: `https://nykschain.twilight.rest/zkos` |
+//! | `FAUCET_BASE_URL` | Testnet faucet | testnet: `https://faucet-rpc.twilight.rest` (empty on mainnet) |
+//! | `TWILIGHT_INDEXER_URL` | Twilight indexer | mainnet: `https://indexer.twilight.org`; testnet: `https://indexer.twilight.rest` |
+//! | `BTC_ESPLORA_PRIMARY_URL` | Primary Esplora API (driven by `BTC_NETWORK_TYPE`) | `https://blockstream.info/api` (mainnet) |
+//! | `BTC_ESPLORA_FALLBACK_URL` | Fallback Esplora API (driven by `BTC_NETWORK_TYPE`) | `https://mempool.space/api` (mainnet) |
+//! | `RELAYER_PROGRAM_JSON_PATH` | Path to relayer program JSON | `./relayerprogram.json` |
+//! | `VALIDATOR_WALLET_PATH` | Validator mnemonic file (`validator-wallet` feature) | `validator.mnemonic` |
+//! | `NYKS_WALLET_PASSPHRASE` | DB encryption passphrase | – (prompt) |
+//! | `WALLET_ID` | DB wallet ID (defaults to Twilight address) | – |
+//! | `DATABASE_URL_SQLITE` | SQLite path (`sqlite` feature) | `./wallet_data.db` |
+//! | `DATABASE_URL_POSTGRESQL` | PostgreSQL DSN (`postgresql` feature) | – |
+//! | `RUST_LOG` | Logging level | – |
 //!
 //! ## Feature Flags
 //!
@@ -162,7 +174,7 @@
 //! - [`error`]: Error types and handling
 //!
 //! For detailed usage examples and API documentation, see the individual module documentation
-//! and the `OrderWalletUpdated.md` guide in the repository.
+//! and the [`OrderWallet.md`](../../OrderWallet.md) guide in the repository.
 
 pub mod nyks_rpc;
 pub mod wallet;

--- a/src/relayer_module/order_wallet.rs
+++ b/src/relayer_module/order_wallet.rs
@@ -16,8 +16,7 @@ use crate::{
     relayer_module::{
         self, check_tx_status, fetch_removed_utxo_details_with_retry,
         fetch_tx_hash_with_account_address_retry, fetch_tx_hash_with_once,
-        fetch_tx_hash_with_retry, fetch_tx_hash_with_retry_with_close_order,
-        fetch_utxo_details_with_once, fetch_utxo_details_with_retry,
+        fetch_tx_hash_with_retry, fetch_utxo_details_with_once, fetch_utxo_details_with_retry,
         nonce_manager::NonceManager,
         relayer_api::RelayerJsonRpcClient,
         relayer_order::{
@@ -2284,166 +2283,175 @@ mod tests {
     // cargo test --no-default-features --features postgresql --lib -- relayer_module::order_wallet::tests::test_create_order --exact --show-output
     // cargo test --no-default-features --features sqlite --lib -- relayer_module::order_wallet::tests::test_create_order --exact --show-output
     // cargo test --all-features --lib -- relayer_module::order_wallet::tests::test_create_order --exact --show-output
-    // #[cfg(feature = "sqlite")]
-    // #[tokio::test]
-    // #[serial]
-    // async fn test_create_order_complete_cycle() -> Result<(), String> {
-    //     dotenv::dotenv().ok();
-    //     unsafe {
-    //         // std::env::set_var("DATABASE_URL", "./test.db");
-    //         std::env::set_var("NYKS_WALLET_PASSPHRASE", "test1_password");
-    //     }
-    //     init_logger();
-    //     let wallet = setup_wallet().await.map_err(|e| e.to_string())?;
-    //     let zk_accounts = ZkAccountDB::new();
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    #[serial]
+    #[ignore]
+    async fn test_create_order_complete_cycle() -> Result<(), String> {
+        dotenv::dotenv().ok();
+        unsafe {
+            // std::env::set_var("DATABASE_URL", "./test.db");
+            std::env::set_var("NYKS_WALLET_PASSPHRASE", "test1_password");
+        }
+        init_logger();
+        let wallet = setup_wallet().await.map_err(|e| e.to_string())?;
+        let zk_accounts = ZkAccountDB::new();
 
-    //     let mut order_wallet = OrderWallet::init(wallet, zk_accounts, EndpointConfig::default())
-    //         .map_err(|e| e.to_string())?;
-    //     order_wallet.with_db(None, None)?;
-    //     let (tx_result, account_index) = order_wallet.funding_to_trading(6000).await?;
-    //     if tx_result.code != 0 {
-    //         return Err(format!("Failed to send tx to chain: {}", tx_result.tx_hash));
-    //     }
+        let mut order_wallet = OrderWallet::init(wallet, zk_accounts, EndpointConfig::default())
+            .map_err(|e| e.to_string())?;
+        // order_wallet.with_db(None, None)?;
+        let (tx_result, account_index) = order_wallet.funding_to_trading(6000).await?;
+        if tx_result.code != 0 {
+            return Err(format!("Failed to send tx to chain: {}", tx_result.tx_hash));
+        }
 
-    //     let btc_price = order_wallet
-    //         .relayer_api_client
-    //         .btc_usd_price()
-    //         .await
-    //         .map_err(|e| e.to_string())?;
-    //     info!("btc_price: {:?}", btc_price);
-    //     let entry_price = btc_price.price as u64;
-    //     let result = order_wallet
-    //         .open_trader_order(
-    //             account_index,
-    //             OrderType::MARKET,
-    //             PositionType::LONG,
-    //             entry_price,
-    //             10,
-    //         )
-    //         .await?;
-    //     info!("result: {:?}", result);
-    //     let tx_hash = fetch_tx_hash_with_retry(&result, &order_wallet.relayer_api_client).await?;
-    //     info!("tx_hash: {:?}", tx_hash);
-    //     assert_eq!(tx_hash.order_status, OrderStatus::FILLED);
-    //     let response = order_wallet.query_trader_order(account_index).await?;
-    //     info!("response: {:?}", response);
-    //     assert_eq!(response.order_status, OrderStatus::FILLED);
-    //     assert_eq!(
-    //         order_wallet
-    //             .zk_accounts
-    //             .get_account(&account_index)?
-    //             .io_type,
-    //         IOType::Memo
-    //     );
+        let btc_price = order_wallet
+            .relayer_api_client
+            .btc_usd_price()
+            .await
+            .map_err(|e| e.to_string())?;
+        info!("btc_price: {:?}", btc_price);
+        let entry_price = btc_price.price as u64;
+        let result = order_wallet
+            .open_trader_order(
+                account_index,
+                OrderType::MARKET,
+                PositionType::LONG,
+                entry_price,
+                10,
+            )
+            .await?;
+        info!("result: {:?}", result);
+        let tx_hash = fetch_tx_hash_with_retry(&result, &order_wallet.relayer_api_client).await?;
+        info!("tx_hash: {:?}", tx_hash);
+        assert_eq!(tx_hash.order_status, OrderStatus::FILLED);
+        let response = order_wallet.query_trader_order(account_index).await?;
+        info!("response: {:?}", response);
+        assert_eq!(response.order_status, OrderStatus::FILLED);
+        assert_eq!(
+            order_wallet
+                .zk_accounts
+                .get_account(&account_index)?
+                .io_type,
+            IOType::Memo
+        );
 
-    //     let result = order_wallet
-    //         .close_trader_order(account_index, OrderType::MARKET, 0.0)
-    //         .await?;
+        let result = order_wallet
+            .close_trader_order(account_index, OrderType::MARKET, 0.0)
+            .await?;
 
-    //     let tx_hash = fetch_tx_hash_with_retry(&result, &order_wallet.relayer_api_client).await?;
-    //     assert_eq!(tx_hash.order_status, OrderStatus::SETTLED);
-    //     let response = order_wallet.query_trader_order(account_index).await?;
-    //     assert_eq!(response.order_status, OrderStatus::SETTLED);
-    //     let zk_account = order_wallet.zk_accounts.get_account(&account_index)?;
-    //     assert_eq!(zk_account.io_type, IOType::Coin);
-    //     assert_eq!(zk_account.balance, response.available_margin as u64);
-    //     let receiver_account_index = order_wallet.trading_to_trading(account_index).await?;
-    //     assert_ne!(account_index, receiver_account_index);
-    //     assert_eq!(
-    //         order_wallet
-    //             .zk_accounts
-    //             .get_account(&account_index)?
-    //             .on_chain,
-    //         false
-    //     );
-    //     info!("receiver_account_index: {:?}", receiver_account_index);
-    //     let result1 = order_wallet
-    //         .open_trader_order(
-    //             receiver_account_index,
-    //             OrderType::MARKET,
-    //             PositionType::LONG,
-    //             entry_price,
-    //             10,
-    //         )
-    //         .await?;
-    //     info!("result1: {:?}", result1);
-    //     let tx_hash1 = fetch_tx_hash_with_retry(&result1, &order_wallet.relayer_api_client).await?;
-    //     info!("tx_hash1: {:?}", tx_hash1);
-    //     assert_eq!(tx_hash1.order_status, OrderStatus::FILLED);
-    //     let response = order_wallet
-    //         .query_trader_order(receiver_account_index)
-    //         .await?;
-    //     info!("response: {:?}", response);
-    //     assert_eq!(response.order_status, OrderStatus::FILLED);
-    //     assert_eq!(
-    //         order_wallet
-    //             .zk_accounts
-    //             .get_account(&receiver_account_index)?
-    //             .io_type,
-    //         IOType::Memo
-    //     );
-    //     let result2 = order_wallet
-    //         .close_trader_order(receiver_account_index, OrderType::MARKET, 0.0)
-    //         .await?;
-    //     let tx_hash2 = fetch_tx_hash_with_retry(&result2, &order_wallet.relayer_api_client).await?;
-    //     assert_eq!(tx_hash2.order_status, OrderStatus::SETTLED);
-    //     let response2 = order_wallet
-    //         .query_trader_order(receiver_account_index)
-    //         .await?;
-    //     assert_eq!(response2.order_status, OrderStatus::SETTLED);
-    //     assert_eq!(
-    //         order_wallet
-    //             .zk_accounts
-    //             .get_account(&receiver_account_index)?
-    //             .io_type,
-    //         IOType::Coin
-    //     );
-    //     let new_recever_index = order_wallet
-    //         .trading_to_trading(receiver_account_index)
-    //         .await?;
-    //     assert_ne!(receiver_account_index, new_recever_index);
-    //     assert_eq!(
-    //         order_wallet
-    //             .zk_accounts
-    //             .get_account(&new_recever_index)?
-    //             .io_type,
-    //         IOType::Coin
-    //     );
-    //     let result3 = order_wallet
-    //         .open_trader_order(
-    //             new_recever_index,
-    //             OrderType::MARKET,
-    //             PositionType::LONG,
-    //             entry_price,
-    //             10,
-    //         )
-    //         .await?;
-    //     let tx_hash3 = fetch_tx_hash_with_retry(&result3, &order_wallet.relayer_api_client).await?;
-    //     info!("tx_hash3: {:?}", tx_hash3);
-    //     assert_eq!(tx_hash3.order_status, OrderStatus::FILLED);
-    //     let response3 = order_wallet.query_trader_order(new_recever_index).await?;
-    //     info!("response3: {:?}", response3);
-    //     assert_eq!(response3.order_status, OrderStatus::FILLED);
-    //     assert_eq!(
-    //         order_wallet
-    //             .zk_accounts
-    //             .get_account(&new_recever_index)?
-    //             .io_type,
-    //         IOType::Memo
-    //     );
-    //     let result4 = order_wallet
-    //         .close_trader_order(new_recever_index, OrderType::MARKET, 0.0)
-    //         .await?;
-    //     debug!("result4: {:?}", result4);
+        let tx_hash = fetch_tx_hash_with_retry(&result, &order_wallet.relayer_api_client).await?;
+        assert_eq!(tx_hash.order_status, OrderStatus::SETTLED);
+        let response = order_wallet.query_trader_order(account_index).await?;
+        assert_eq!(response.order_status, OrderStatus::SETTLED);
+        order_wallet.unlock_trader_order(account_index).await?;
+        let zk_account = order_wallet.zk_accounts.get_account(&account_index)?;
+        assert_eq!(zk_account.io_type, IOType::Coin);
+        assert_eq!(zk_account.balance, response.available_margin as u64);
+        let receiver_account_index = order_wallet.trading_to_trading(account_index).await?;
+        assert_ne!(account_index, receiver_account_index);
+        assert_eq!(
+            order_wallet
+                .zk_accounts
+                .get_account(&account_index)?
+                .on_chain,
+            false
+        );
+        info!("receiver_account_index: {:?}", receiver_account_index);
+        let result1 = order_wallet
+            .open_trader_order(
+                receiver_account_index,
+                OrderType::MARKET,
+                PositionType::LONG,
+                entry_price,
+                10,
+            )
+            .await?;
+        info!("result1: {:?}", result1);
+        let tx_hash1 = fetch_tx_hash_with_retry(&result1, &order_wallet.relayer_api_client).await?;
+        info!("tx_hash1: {:?}", tx_hash1);
+        assert_eq!(tx_hash1.order_status, OrderStatus::FILLED);
+        let response = order_wallet
+            .query_trader_order(receiver_account_index)
+            .await?;
+        info!("response: {:?}", response);
+        assert_eq!(response.order_status, OrderStatus::FILLED);
+        assert_eq!(
+            order_wallet
+                .zk_accounts
+                .get_account(&receiver_account_index)?
+                .io_type,
+            IOType::Memo
+        );
+        let result2 = order_wallet
+            .close_trader_order(receiver_account_index, OrderType::MARKET, 0.0)
+            .await?;
+        let tx_hash2 = fetch_tx_hash_with_retry(&result2, &order_wallet.relayer_api_client).await?;
+        assert_eq!(tx_hash2.order_status, OrderStatus::SETTLED);
+        let response2 = order_wallet
+            .query_trader_order(receiver_account_index)
+            .await?;
+        assert_eq!(response2.order_status, OrderStatus::SETTLED);
+        order_wallet
+            .unlock_trader_order(receiver_account_index)
+            .await?;
+        order_wallet
+            .sync_account_state(receiver_account_index)
+            .await?;
+        assert_eq!(
+            order_wallet
+                .zk_accounts
+                .get_account(&receiver_account_index)?
+                .io_type,
+            IOType::Coin
+        );
+        let new_recever_index = order_wallet
+            .trading_to_trading(receiver_account_index)
+            .await?;
+        assert_ne!(receiver_account_index, new_recever_index);
+        assert_eq!(
+            order_wallet
+                .zk_accounts
+                .get_account(&new_recever_index)?
+                .io_type,
+            IOType::Coin
+        );
+        let result3 = order_wallet
+            .open_trader_order(
+                new_recever_index,
+                OrderType::MARKET,
+                PositionType::LONG,
+                entry_price,
+                10,
+            )
+            .await?;
+        let tx_hash3 = fetch_tx_hash_with_retry(&result3, &order_wallet.relayer_api_client).await?;
+        info!("tx_hash3: {:?}", tx_hash3);
+        assert_eq!(tx_hash3.order_status, OrderStatus::FILLED);
+        let response3 = order_wallet.query_trader_order(new_recever_index).await?;
+        info!("response3: {:?}", response3);
+        assert_eq!(response3.order_status, OrderStatus::FILLED);
+        assert_eq!(
+            order_wallet
+                .zk_accounts
+                .get_account(&new_recever_index)?
+                .io_type,
+            IOType::Memo
+        );
+        let result4 = order_wallet
+            .close_trader_order(new_recever_index, OrderType::MARKET, 0.0)
+            .await?;
+        debug!("result4: {:?}", result4);
 
-    //     Ok(())
-    // }
+        Ok(())
+    }
     // cargo test --no-default-features --features postgresql --lib -- relayer_module::order_wallet::tests::test_create_order --exact --show-output
     // cargo test --no-default-features --features sqlite --lib -- relayer_module::order_wallet::tests::test_create_order --exact --show-output
     // cargo test --all-features --lib -- relayer_module::order_wallet::tests::test_create_order --exact --show-output
     // #[cfg(feature = "sqlite")]
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn test_create_order_complete_cycle_sltp() -> Result<(), String> {
         dotenv::dotenv().ok();
         unsafe {
@@ -2456,7 +2464,7 @@ mod tests {
 
         let mut order_wallet = OrderWallet::init(wallet, zk_accounts, EndpointConfig::default())
             .map_err(|e| e.to_string())?;
-        order_wallet.with_db(None, None)?;
+        // order_wallet.with_db(None, None)?;
         let (tx_result, account_index) = order_wallet.funding_to_trading(6000).await?;
         if tx_result.code != 0 {
             return Err(format!("Failed to send tx to chain: {}", tx_result.tx_hash));
@@ -2503,108 +2511,10 @@ mod tests {
             )
             .await?;
 
-        // let tx_hash = fetch_tx_hash_with_retry(&result, &order_wallet.relayer_api_client).await?;
-        // assert_eq!(tx_hash.order_status, OrderStatus::SETTLED);
-        // let response = order_wallet.query_trader_order(account_index).await?;
-        // assert_eq!(response.order_status, OrderStatus::SETTLED);
-        // let zk_account = order_wallet.zk_accounts.get_account(&account_index)?;
-        // assert_eq!(zk_account.io_type, IOType::Coin);
-        // assert_eq!(zk_account.balance, response.available_margin as u64);
-        // let receiver_account_index = order_wallet.trading_to_trading(account_index).await?;
-        // assert_ne!(account_index, receiver_account_index);
-        // assert_eq!(
-        //     order_wallet
-        //         .zk_accounts
-        //         .get_account(&account_index)?
-        //         .on_chain,
-        //     false
-        // );
-        // info!("receiver_account_index: {:?}", receiver_account_index);
-        // let result1 = order_wallet
-        //     .open_trader_order(
-        //         receiver_account_index,
-        //         OrderType::MARKET,
-        //         PositionType::LONG,
-        //         entry_price,
-        //         10,
-        //     )
-        //     .await?;
-        // info!("result1: {:?}", result1);
-        // let tx_hash1 = fetch_tx_hash_with_retry(&result1, &order_wallet.relayer_api_client).await?;
-        // info!("tx_hash1: {:?}", tx_hash1);
-        // assert_eq!(tx_hash1.order_status, OrderStatus::FILLED);
-        // let response = order_wallet
-        //     .query_trader_order(receiver_account_index)
-        //     .await?;
-        // info!("response: {:?}", response);
-        // assert_eq!(response.order_status, OrderStatus::FILLED);
-        // assert_eq!(
-        //     order_wallet
-        //         .zk_accounts
-        //         .get_account(&receiver_account_index)?
-        //         .io_type,
-        //     IOType::Memo
-        // );
-        // let result2 = order_wallet
-        //     .close_trader_order_sltp(
-        //         receiver_account_index,
-        //         OrderType::MARKET,
-        //         0.0,
-        //         Some(entry_price as f64 - 1000.0),
-        //         Some(entry_price as f64 + 1000.0),
-        //     )
-        //     .await?;
-        // let tx_hash2 = fetch_tx_hash_with_retry(&result2, &order_wallet.relayer_api_client).await?;
-        // assert_eq!(tx_hash2.order_status, OrderStatus::SETTLED);
-        // let response2 = order_wallet
-        //     .query_trader_order(receiver_account_index)
-        //     .await?;
-        // assert_eq!(response2.order_status, OrderStatus::SETTLED);
-        // assert_eq!(
-        //     order_wallet
-        //         .zk_accounts
-        //         .get_account(&receiver_account_index)?
-        //         .io_type,
-        //     IOType::Coin
-        // );
-        // let new_recever_index = order_wallet
-        //     .trading_to_trading(receiver_account_index)
-        //     .await?;
-        // assert_ne!(receiver_account_index, new_recever_index);
-        // assert_eq!(
-        //     order_wallet
-        //         .zk_accounts
-        //         .get_account(&new_recever_index)?
-        //         .io_type,
-        //     IOType::Coin
-        // );
-        // let result3 = order_wallet
-        //     .open_trader_order(
-        //         new_recever_index,
-        //         OrderType::MARKET,
-        //         PositionType::LONG,
-        //         entry_price,
-        //         10,
-        //     )
-        //     .await?;
-        // let tx_hash3 = fetch_tx_hash_with_retry(&result3, &order_wallet.relayer_api_client).await?;
-        // info!("tx_hash3: {:?}", tx_hash3);
-        // assert_eq!(tx_hash3.order_status, OrderStatus::FILLED);
-        // let response3 = order_wallet.query_trader_order(new_recever_index).await?;
-        // info!("response3: {:?}", response3);
-        // assert_eq!(response3.order_status, OrderStatus::FILLED);
-        // assert_eq!(
-        //     order_wallet
-        //         .zk_accounts
-        //         .get_account(&new_recever_index)?
-        //         .io_type,
-        //     IOType::Memo
-        // );
-        // let result4 = order_wallet
-        //     .close_trader_order(new_recever_index, OrderType::MARKET, 0.0)
-        //     .await?;
-        // debug!("result4: {:?}", result4);
-
+        let tx_hash = fetch_tx_hash_with_retry(&result, &order_wallet.relayer_api_client).await?;
+        println!("tx_hash: {:?}", tx_hash);
+        let response = order_wallet.query_trader_order(account_index).await?;
+        println!("response: {:?}", response);
         Ok(())
     }
 
@@ -2711,6 +2621,8 @@ mod tests {
         assert_eq!(tx_hash.order_status, OrderStatus::SETTLED);
         let response = order_wallet.query_lend_order(account_index).await?;
         assert_eq!(response.order_status, OrderStatus::SETTLED);
+        order_wallet.unlock_lend_order(account_index).await?;
+        order_wallet.sync_account_state(account_index).await?;
         let zk_account = order_wallet.zk_accounts.get_account(&account_index)?;
         assert_eq!(zk_account.io_type, IOType::Coin);
         assert_eq!(zk_account.balance, response.new_lend_state_amount as u64);
@@ -2719,6 +2631,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn test_create_order_with_cancel() -> Result<(), String> {
         dotenv::dotenv().ok();
         init_logger();
@@ -2775,6 +2688,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn test_get_wallet_list_from_db() -> Result<(), String> {
         dotenv::dotenv().ok();
         init_logger();
@@ -2786,19 +2700,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn test_get_wallet_list_from_db_with_db_url() -> Result<(), String> {
-        dotenv::dotenv().ok();
-        init_logger();
-        let mut order_wallet = OrderWallet::new(None).map_err(|e| e.to_string())?;
-        order_wallet.with_db(None, None)?;
-        drop(order_wallet);
-        let wallet_list = OrderWallet::get_wallet_list_from_db(None).map_err(|e| e.to_string())?;
-        println!("wallet_list: {:?}", wallet_list);
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[serial]
+    #[ignore]
     async fn test_with_db() -> Result<(), String> {
         dotenv::dotenv().ok();
         init_logger();
@@ -2811,6 +2713,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    #[ignore]
     async fn test_trading_to_trading_multiple_accounts() -> Result<(), String> {
         dotenv::dotenv().ok();
         init_logger();
@@ -2868,30 +2771,6 @@ mod tests {
             IOType::Memo
         );
 
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[serial]
-    async fn test_load_encrypted_wallet() -> Result<(), String> {
-        dotenv::dotenv().ok();
-        init_logger();
-        let wallet_id = "load_encrypted_wallet_test".to_string();
-        let mut order_wallet;
-        let wallet_exists = OrderWallet::get_wallet_id_from_db(&wallet_id, None)?;
-        if wallet_exists {
-            order_wallet =
-                OrderWallet::load_from_db(wallet_id, None, None).map_err(|e| e.to_string())?;
-        } else {
-            order_wallet = OrderWallet::new(None).map_err(|e| e.to_string())?;
-            order_wallet
-                .with_db(None, Some(wallet_id))
-                .map_err(|e| e.to_string())?;
-        }
-        get_test_tokens(&mut order_wallet.wallet)
-            .await
-            .map_err(|e| e.to_string())?;
-        drop(order_wallet);
         Ok(())
     }
 

--- a/src/relayer_module/relayer_api.rs
+++ b/src/relayer_module/relayer_api.rs
@@ -427,15 +427,16 @@ impl<T: Serialize> ToRpcParams for AsRpcParams<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::relayer_module::relayer_types::OrderStatus;
-
     use super::*;
+    use crate::config::RelayerEndPointConfig;
+    use crate::relayer_module::relayer_types::OrderStatus;
     use crate::relayer_module::relayer_types::{Interval, TransactionHashArgs};
     #[tokio::test]
     async fn test_transaction_hashes_by_request_id() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
 
         let request_id = TransactionHashArgs::RequestId {
@@ -457,8 +458,9 @@ mod tests {
     #[tokio::test]
     async fn test_position_size() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
 
         match relayer.position_size().await {
@@ -472,8 +474,9 @@ mod tests {
     #[tokio::test]
     async fn test_pool_share_value() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
 
         match relayer.pool_share_value().await {
@@ -487,8 +490,9 @@ mod tests {
     #[tokio::test]
     async fn test_lend_pool_info() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
 
         match relayer.lend_pool_info().await {
@@ -502,8 +506,9 @@ mod tests {
     #[tokio::test]
     async fn test_historical_funding() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
         let args = HistoricalFundingArgs {
             from: chrono::Utc::now() - chrono::Duration::hours(24),
@@ -524,8 +529,9 @@ mod tests {
     #[tokio::test]
     async fn test_historical_fees() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
         let args = HistoricalFeeArgs {
             from: chrono::Utc::now() - chrono::Duration::days(365),
@@ -546,8 +552,9 @@ mod tests {
     #[tokio::test]
     async fn test_historical_prices() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
         let args = HistoricalPriceArgs {
             from: chrono::Utc::now() - chrono::Duration::hours(24),
@@ -569,8 +576,9 @@ mod tests {
     #[tokio::test]
     async fn test_btc_usd_price() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
         match relayer.btc_usd_price().await {
             Ok(price) => println!("BTC/USD price: {:?}", price),
@@ -584,8 +592,9 @@ mod tests {
     #[tokio::test]
     async fn test_open_limit_orders() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
         match relayer.open_limit_orders().await {
             Ok(order_book) => println!("Open limit orders: {:?}", order_book),
@@ -599,8 +608,9 @@ mod tests {
     #[tokio::test]
     async fn test_recent_trade_orders() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
         match relayer.recent_trade_orders().await {
             Ok(orders) => println!("Recent trade orders: {:?}", orders),
@@ -614,8 +624,9 @@ mod tests {
     #[tokio::test]
     async fn test_candle_data() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
         let args = Candles {
             interval: Interval::ONE_MINUTE,
@@ -635,8 +646,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_funding_rate() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
         match relayer.get_funding_rate().await {
             Ok(rate) => println!("Funding rate: {:?}", rate),
@@ -650,8 +662,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_fee_rate() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
         match relayer.get_fee_rate().await {
             Ok(fee) => println!("Fee rate: {:?}", fee),
@@ -665,8 +678,9 @@ mod tests {
     #[tokio::test]
     async fn test_historical_trader_order_info() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
         let query_str = "8a00000000000000306339363431313165653936636436663332656333363734353065656130636464663632343439393766623339366265323464623335363063653831616133333435313633393733333265316135386131646162623135346134346539663631616163386436663264323366386338386464623435306332623065626663373831633239366638343761050000008a000000000000003063393634313131656539366364366633326563333637343530656561306364646636323434393937666233393662653234646233353630636538316161333334353136333937333332653161353861316461626231353461343465396636316161633864366632643233663863383864646234353063326230656266633738316332393666383437614000000000000000bcdd784e30b11b3d80b039e951e2de9ce68bc9e12254f588872a4cb05621916267f41835ff570ed81f53e4553f055b6b3e691d75910b4e5ae0d9d5556f5b0e08".to_string();
         let query = QueryTraderOrderZkos::decode_from_hex_string(query_str).unwrap();
@@ -682,8 +696,9 @@ mod tests {
     #[ignore]
     async fn test_trader_order_info() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
         let query_str = "8a00000000000000306339363431313165653936636436663332656333363734353065656130636464663632343439393766623339366265323464623335363063653831616133333435313633393733333265316135386131646162623135346134346539663631616163386436663264323366386338386464623435306332623065626663373831633239366638343761050000008a000000000000003063393634313131656539366364366633326563333637343530656561306364646636323434393937666233393662653234646233353630636538316161333334353136333937333332653161353861316461626231353461343465396636316161633864366632643233663863383864646234353063326230656266633738316332393666383437614000000000000000bcdd784e30b11b3d80b039e951e2de9ce68bc9e12254f588872a4cb05621916267f41835ff570ed81f53e4553f055b6b3e691d75910b4e5ae0d9d5556f5b0e08".to_string();
         let query = QueryTraderOrderZkos::decode_from_hex_string(query_str).unwrap();
@@ -699,8 +714,9 @@ mod tests {
     #[ignore]
     async fn test_lend_order_info() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
         let query_str = "8a00000000000000306366383562333461346538383936643232333035623462333831636335663237383535373631616361356361323761376237636366663561663536623330343238336334303266656363363634346561323638663031643661643466356631663736663066383631386261323533353963623462353064623530653638363733313031653037653934050000008a000000000000003063663835623334613465383839366432323330356234623338316363356632373835353736316163613563613237613762376363666635616635366233303432383363343032666563633636343465613236386630316436616434663566316637366630663836313862613235333539636234623530646235306536383637333130316530376539344000000000000000622ec112f3087ef15f6265c4d600c53098ebb27310f3296f1dbcfa3c165a7b4ce780d5cf9fc7dd2ef89fe127ef16188fe5811b6e4a8f1e0c90c92bb96be7a302".to_string();
         let query = QueryLendOrderZkos::decode_from_hex_string(query_str).unwrap();
@@ -715,8 +731,9 @@ mod tests {
     #[tokio::test]
     async fn test_server_time() {
         dotenv::dotenv().ok();
-        let relayer_url = std::env::var("RELAYER_API_RPC_SERVER_URL")
-            .unwrap_or("http://0.0.0.0:8088/api".to_string());
+        let relayer_url = RelayerEndPointConfig::from_env()
+            .relayer_api_endpoint
+            .clone();
         let relayer = RelayerJsonRpcClient::new(&relayer_url).unwrap();
         match relayer.server_time().await {
             Ok(time) => println!("Server time: {:?}", time),

--- a/src/test.rs
+++ b/src/test.rs
@@ -330,29 +330,4 @@ mod tests {
             Err(e) => println!("Failed to export to json: {}", e),
         }
     }
-
-    // This test creates a wallet from a keyring file and prints the wallet details.
-    // RUST_LOG=debug cargo test --package nyks-wallet --lib --all-features -- test::tests::test_wallet_from_keyring_file --exact --show-output
-    #[tokio::test]
-    #[serial]
-    async fn test_wallet_from_keyring_file() -> anyhow::Result<()> {
-        dotenv::dotenv().ok();
-        init_logger();
-        // global_setup().await;
-        let wallet = Wallet::from_mnemonic_file("validator-self.mnemonic")?;
-        let balance =
-            check_balance(&wallet.twilightaddress, &wallet.chain_config.lcd_endpoint).await?;
-        println!("balance: {:?}", balance);
-        println!("wallet: {:?}", wallet);
-        Ok(())
-    }
-    #[tokio::test]
-    #[serial]
-    async fn test_wallet_from_mnemonic_new() -> anyhow::Result<()> {
-        dotenv::dotenv().ok();
-        init_logger();
-        let wallet = Wallet::new(None)?;
-        println!("wallet: {:?}", wallet);
-        Ok(())
-    }
 }

--- a/src/wallet/btc_wallet/btc_wallet.rs
+++ b/src/wallet/btc_wallet/btc_wallet.rs
@@ -44,7 +44,11 @@ impl BtcNetwork {
 
 impl std::fmt::Display for BtcWallet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "BtcWallet(address={}, network={:?})", self.address, self.network)
+        write!(
+            f,
+            "BtcWallet(address={}, network={:?})",
+            self.address, self.network
+        )
     }
 }
 
@@ -106,7 +110,7 @@ mod tests {
 
     #[test]
     fn test_from_mnemonic() {
-        let mnemonic = "fragile suffer other retire often wrong ribbon alcohol wine dutch wet cancel physical dignity awkward trophy atom twist cover seminar voice only describe slide";
+        let mnemonic = "test test test test test test test test test test test junk";
         let btc = BtcWallet::from_mnemonic(mnemonic).unwrap();
 
         assert!(btc.address.starts_with("bc1q"));
@@ -123,7 +127,7 @@ mod tests {
 
     #[test]
     fn test_consistent_with_legacy_keys() {
-        let mnemonic = "fragile suffer other retire often wrong ribbon alcohol wine dutch wet cancel physical dignity awkward trophy atom twist cover seminar voice only describe slide";
+        let mnemonic = "test test test test test test test test test test test junk";
         let btc = BtcWallet::from_mnemonic(mnemonic).unwrap();
         let (_wif, addr) = super::super::keys::segwit_from_mnemonic(mnemonic).unwrap();
 
@@ -133,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_create_bdk_wallet() {
-        let mnemonic = "fragile suffer other retire often wrong ribbon alcohol wine dutch wet cancel physical dignity awkward trophy atom twist cover seminar voice only describe slide";
+        let mnemonic = "test test test test test test test test test test test junk";
         let btc = BtcWallet::from_mnemonic(mnemonic).unwrap();
         let bdk = btc.create_bdk_wallet().unwrap();
 

--- a/src/wallet/nyks_fn.rs
+++ b/src/wallet/nyks_fn.rs
@@ -4,12 +4,12 @@ pub use super::super::MsgMintBurnTradingBtc;
 use super::faucet::fetch_account_details;
 use super::wallet::*;
 use anyhow::anyhow;
-use base64::{Engine as _, engine::general_purpose};
+use base64::{engine::general_purpose, Engine as _};
 use cosmrs::tendermint::chain::Id;
 use cosmrs::tx::{Body, Fee, SignDoc, SignerInfo};
 use prost::Message;
 use reqwest::header::HeaderMap;
-use reqwest::header::{ACCEPT, ACCEPT_ENCODING, CONTENT_TYPE, HeaderValue, USER_AGENT};
+use reqwest::header::{HeaderValue, ACCEPT, ACCEPT_ENCODING, CONTENT_TYPE, USER_AGENT};
 use serde_json::Value;
 use std::str::FromStr;
 
@@ -119,25 +119,6 @@ mod tests {
             encrypt_scalar,
             twilight_address,
         );
-    }
-    #[tokio::test]
-    async fn test_send_tx() -> anyhow::Result<()> {
-        dotenv::dotenv().ok();
-        let rpc_endpoint =
-            std::env::var("NYKS_RPC_BASE_URL").unwrap_or("http://0.0.0.0:26657".to_string());
-        let lcd_endpoint =
-            std::env::var("NYKS_LCD_BASE_URL").unwrap_or("http://0.0.0.0:1317".to_string());
-        let (qq_account, encrypt_scalar) = get_quisquis_account();
-        let twilight_address = "twilight1ykm5td5kw2hwafmhn7qha54p20veh9um05dpjn".to_string();
-        let msg = create_funiding_to_trading_tx_msg(
-            true,
-            40000,
-            qq_account,
-            encrypt_scalar,
-            twilight_address,
-        );
-        send_tx(msg, rpc_endpoint.as_str(), lcd_endpoint.as_str()).await?;
-        Ok(())
     }
 }
 

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -1432,6 +1432,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     async fn test_fetch_btc_proposed_reserve() {
         let wallet = Wallet::from_mnemonic(
             "test test test test test test test test test test test junk",


### PR DESCRIPTION
## Summary
- Add `relayer-cli update` self-updating command with checksum verification
- Add install scripts (`install.sh`, `install.ps1`) for Unix-like systems and Windows, with Linux ARM64 support
- Enhance release workflow, help output, and docs (including agent-skill docs) for installation/configuration

## Test plan
- [ ] `install.sh` succeeds on macOS and Linux (x86_64 + ARM64)
- [ ] `install.ps1` succeeds on Windows
- [ ] `relayer-cli update` downloads, verifies checksum, and replaces binary
- [ ] `relayer-cli --help` / `--version` show updated output and build date